### PR TITLE
Update ci system

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -81,6 +81,7 @@ PenaltyReturnTypeOnItsOwnLine: 60
 
 PointerAlignment: Right
 ReflowComments: false
+SkipMacroDefinitionBody: true
 SortIncludes: false
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
@@ -181,7 +182,7 @@ ReferenceAlignment: Right
 RemoveSemicolon: false
 RequiresClausePosition: WithPreceding
 RequiresExpressionIndentation: OuterScope
-SeparateDefinitionBlocks: Always
+SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1
 SortIncludes: false
 #SortUsingDeclarations: LexicographicNumeric

--- a/.github/actions/build-plugin/action.yaml
+++ b/.github/actions/build-plugin/action.yaml
@@ -16,6 +16,10 @@ inputs:
     description: Developer ID for application codesigning (macOS only)
     required: false
     default: '-'
+  codesignTeam:
+    description: Team ID for application codesigning (macOS only)
+    required: false
+    default: ''
   workingDirectory:
     description: Working directory for packaging
     required: false

--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -35,7 +35,7 @@ runs:
         echo ::group::Install Dependencies
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-        echo "/home/linuxbrew/.linuxbrew/opt/clang-format@17/bin" >> $GITHUB_PATH
+        echo "/home/linuxbrew/.linuxbrew/opt/clang-format@19/bin" >> $GITHUB_PATH
         brew install --quiet zsh
         echo ::endgroup::
 
@@ -50,11 +50,11 @@ runs:
         : Run clang-format 🐉
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-        print ::group::Install clang-format-17
-        brew install --quiet obsproject/tools/clang-format@17
+        print ::group::Install clang-format-19
+        brew install --quiet obsproject/tools/clang-format@19
         print ::endgroup::
 
-        print ::group::Run clang-format-17
+        print ::group::Run clang-format-19
         local -a changes=(${(s:,:)CHANGED_FILES//[\[\]\'\"]/})
         ./build-aux/run-clang-format --fail-${{ inputs.failCondition }} --check ${changes}
         print ::endgroup::

--- a/.github/scripts/build-macos
+++ b/.github/scripts/build-macos
@@ -110,14 +110,6 @@ build() {
     typeset -gx CODESIGN_TEAM="$(print "${CODESIGN_IDENT}" | /usr/bin/sed -En 's/.+\((.+)\)/\1/p')"
   }
 
-  log_group "Xcode and SDK Info"
-  export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
-  export DEVELOPER_DIR="/Applications/Xcode_16.1.0.app/Contents/Developer"
-  xcodebuild -version
-  xcodebuild -showsdks
-  xcode-select -p
-  xcrun --show-sdk-version
-
   log_group "Configuring ${product_name}..."
   cmake -S ${project_root} ${cmake_args}
 

--- a/.github/scripts/utils.zsh/check_macos
+++ b/.github/scripts/utils.zsh/check_macos
@@ -1,16 +1,5 @@
 autoload -Uz is-at-least log_group log_info log_error log_status
 
-local macos_version=$(sw_vers -productVersion)
-
-log_group 'Install macOS build requirements'
-log_info 'Checking macOS version...'
-if ! is-at-least 11.0 ${macos_version}; then
-  log_error "Minimum required macOS version is 11.0, but running on macOS ${macos_version}"
-  return 2
-else
-  log_status "macOS ${macos_version} is recent"
-fi
-
 log_info 'Checking for Homebrew...'
 if (( ! ${+commands[brew]} )) {
   log_error 'No Homebrew command found. Please install Homebrew (https://brew.sh)'

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,7 +17,7 @@
     {
       "name": "macos",
       "displayName": "macOS Universal",
-      "description": "Build for macOS 11.0+ (Universal binary)",
+      "description": "Build for macOS 12.0+ (Universal binary)",
       "inherits": ["template"],
       "binaryDir": "${sourceDir}/build_macos",
       "condition": {
@@ -28,7 +28,7 @@
       "generator": "Xcode",
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "CMAKE_OSX_ARCHITECTURES": "arm64;x86_64",
         "CODESIGN_IDENTITY": "$penv{CODESIGN_IDENT}",
         "CODESIGN_TEAM": "$penv{CODESIGN_TEAM}"
@@ -38,7 +38,7 @@
       "name": "macos-ci",
       "inherits": ["macos"],
       "displayName": "macOS Universal CI build",
-      "description": "Build for macOS 11.0+ (Universal binary) for CI",
+      "description": "Build for macOS 12.0+ (Universal binary) for CI",
       "generator": "Xcode",
       "cacheVariables": {
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,

--- a/build-aux/.run-format.zsh
+++ b/build-aux/.run-format.zsh
@@ -33,23 +33,23 @@ invoke_formatter() {
 
   case ${formatter} {
     clang)
-      if (( ${+commands[clang-format-17]} )) {
-        local formatter=clang-format-17
+      if (( ${+commands[clang-format-19]} )) {
+        local formatter=clang-format-19
       } elif (( ${+commands[clang-format]} )) {
         local formatter=clang-format
       } else {
-        log_error "No viable clang-format version found (required 17.0.3)"
+        log_error "No viable clang-format version found (required 19.1.1)"
         exit 2
       }
 
       local -a formatter_version=($(${formatter} --version))
 
-      if ! is-at-least 17.0.3 ${formatter_version[-1]}; then
-        log_error "clang-format is not version 17.0.3 or above (found ${formatter_version[-1]}."
+      if ! is-at-least 19.1.1 ${formatter_version[-1]}; then
+        log_error "clang-format is not version 19.1.1 or above (found ${formatter_version[-1]}."
         exit 2
       fi
 
-      if ! is-at-least ${formatter_version[-1]} 17.0.3; then
+      if ! is-at-least ${formatter_version[-1]} 19.1.1; then
         log_error "clang-format is more recent than version 17.0.3 (found ${formatter_version[-1]})."
         exit 2
       fi

--- a/build-aux/.run-format.zsh
+++ b/build-aux/.run-format.zsh
@@ -50,7 +50,7 @@ invoke_formatter() {
       fi
 
       if ! is-at-least ${formatter_version[-1]} 19.1.1; then
-        log_error "clang-format is more recent than version 17.0.3 (found ${formatter_version[-1]})."
+        log_error "clang-format is more recent than version 19.1.1 (found ${formatter_version[-1]})."
         exit 2
       fi
 

--- a/buildspec.json
+++ b/buildspec.json
@@ -1,33 +1,33 @@
 {
     "dependencies": {
         "obs-studio": {
-            "version": "31.0.0",
+            "version": "31.1.1",
             "baseUrl": "https://github.com/obsproject/obs-studio/archive/refs/tags",
             "label": "OBS sources",
             "hashes": {
-                "macos": "a22966ff07aba38833ba57c36c9e0d190d083be5dec5048d0a60cd9e6b997242",
-                "windows-x64": "e8434dcee06f1702f0a0bbd1489296c77116fc51356835c3af4a6ed21b1e1c74"
+                "macos": "39751f067bacc13d44b116c5138491b5f1391f91516d3d590d874edd21292291",
+                "windows-x64": "2c8427c10b55ac6d68008df2e9a3e82f4647aaad18f105e30d4713c2de678ccf"
             }
         },
         "prebuilt": {
-            "version": "2024-09-12",
+            "version": "2025-07-11",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built obs-deps",
             "hashes": {
-                "macos": "c857b211ee378772994b632036e1e5befe66b37e85286cb8e3cefc1435d5220a",
-                "windows-x64": "d4a4f194591766891ad3c0b267deec3c4b85239c8fe557273559927456aeedbb"
+                "macos": "495687e63383d1a287684b6e2e9bfe246bb8f156fe265926afb1a325af1edd2a",
+                "windows-x64": "c8c642c1070dc31ce9a0f1e4cef5bb992f4bff4882255788b5da12129e85caa7"
             }
         },
         "qt6": {
-            "version": "2024-09-12",
+            "version": "2025-07-11",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built Qt6",
             "hashes": {
-                "macos": "34a2de6b7f4d4d58fc5a15a4dba49a61d81a4045d0cedfc1a1f08c0dfb8047cf",
-                "windows-x64": "4d15ce13dbb0a8a2cabcce5ae0da5e80ee589b482a61b2025378465c1da32c4f"
+                "macos": "d3f5f04b6ea486e032530bdf0187cbda9a54e0a49621a4c8ba984c5023998867",
+                "windows-x64": "0e76bf0555dd5382838850b748d3dcfab44a1e1058441309ab54e1a65b156d0a"
             },
             "debugSymbols": {
-                "windows-x64": "dad2351a5c9cd438168e1ed8fb453a2534532252edb555f1001a5e8eb3f1bbd4"
+                "windows-x64": "11b7be92cf66a273299b8f3515c07a5cfb61614b59a4e67f7fc5ecba5e2bdf21"
             }
         }
     },

--- a/cmake/common/buildspec_common.cmake
+++ b/cmake/common/buildspec_common.cmake
@@ -67,7 +67,7 @@ function(_setup_obs_studio)
     COMMAND
       "${CMAKE_COMMAND}" -S "${dependencies_dir}/${_obs_destination}" -B
       "${dependencies_dir}/${_obs_destination}/build_${arch}" -G ${_cmake_generator} "${_cmake_arch}"
-      -DOBS_CMAKE_VERSION:STRING=3.0.0 -DENABLE_PLUGINS:BOOL=OFF -DENABLE_UI:BOOL=OFF
+      -DOBS_CMAKE_VERSION:STRING=3.0.0 -DENABLE_PLUGINS:BOOL=OFF -DENABLE_FRONTEND:BOOL=OFF
       -DOBS_VERSION_OVERRIDE:STRING=${_obs_version} "-DCMAKE_PREFIX_PATH='${CMAKE_PREFIX_PATH}'" ${_is_fresh}
       ${_cmake_extra}
     RESULT_VARIABLE _process_result


### PR DESCRIPTION
This pull request updates the build system and dependencies to support newer versions of macOS and clang-format, and refreshes dependency versions and their configuration. The changes ensure compatibility with macOS 12.0+, require clang-format 19.1.1, and update dependency hashes for improved reliability. Several configuration and script files have been modified to reflect these requirements.

**Build system and platform requirements:**

* Updated macOS build presets in `CMakePresets.json` to require macOS 12.0+ and set `CMAKE_OSX_DEPLOYMENT_TARGET` to 12.0, replacing the previous 11.0 requirement. [[1]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L20-R20) [[2]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L31-R31) [[3]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L41-R41)
* Removed the explicit macOS version check from `.github/scripts/utils.zsh/check_macos`, simplifying environment validation.

**Dependency and toolchain updates:**

* Updated the required version of `clang-format` from 17.0.3 to 19.1.1 in scripts and GitHub actions, and changed installation and path references accordingly. [[1]](diffhunk://#diff-564e60d9f3c0e1a7f4b2a78e0238ef49ba2f3a23ff896733df851d9235f898dbL38-R38) [[2]](diffhunk://#diff-564e60d9f3c0e1a7f4b2a78e0238ef49ba2f3a23ff896733df851d9235f898dbL53-R57) [[3]](diffhunk://#diff-e35ab26e01f8000e5a9099f2277135b686f255ffb18deb254ed49d61ac019c06L36-R53)
* Refreshed dependency versions and hashes in `buildspec.json` for `obs-studio`, `prebuilt`, and `qt6` to their latest releases.

**Configuration improvements:**

* Added an optional `codesignTeam` input to `.github/actions/build-plugin/action.yaml` for improved macOS codesigning flexibility.
* Changed OBS Studio configuration in `cmake/common/buildspec_common.cmake` to disable the frontend instead of the UI, aligning with updated build requirements.

**Formatting and style configuration:**

* Updated `.clang-format` to skip macro definition bodies and adjusted definition block separation for improved formatting control. [[1]](diffhunk://#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2R84) [[2]](diffhunk://#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2L184-R185)

**Miscellaneous:**

* Removed Xcode and SDK info logging from the macOS build script for a cleaner build output.