### PR TITLE
Add luminance extraction effect and mode option

### DIFF
--- a/data/effects/drawing-emphasizer.effect
+++ b/data/effects/drawing-emphasizer.effect
@@ -1,9 +1,11 @@
 uniform float4x4 ViewProj;
 
 uniform texture2d image;
-uniform float sensitivityFactor;
+
 uniform float texelWidth;
 uniform float texelHeight;
+
+uniform float sensitivityFactor;
 
 sampler_state textureSampler {
   Filter = Linear;

--- a/data/effects/luminance-extraction.effect
+++ b/data/effects/luminance-extraction.effect
@@ -1,0 +1,46 @@
+uniform float4x4 ViewProj;
+
+uniform texture2d image;
+
+uniform float texelWidth;
+uniform float texelHeight;
+
+sampler_state textureSampler {
+  Filter = Linear;
+  AddressU = Clamp;
+  AddressV = Clamp;
+};
+
+struct VertDataIn {
+  float4 pos : POSITION;
+  float2 uv : TEXCOORD0;
+};
+
+struct VertDataOut {
+  float4 pos : POSITION;
+  float2 uv : TEXCOORD0;
+};
+
+VertDataOut VSDefault(VertDataIn v_in)
+{
+  VertDataOut v_out;
+  v_out.pos = mul(float4(v_in.pos.xyz, 1.0), ViewProj);
+  v_out.uv  = v_in.uv;
+  return v_out;
+}
+
+float4 PSLuminanceExtraction(VertDataOut v_in) : TARGET
+{
+  float4 color = image.Sample(textureSampler, v_in.uv);
+  float luminance = dot(color.rgb, float3(0.299, 0.587, 0.114));
+  return float4(luminance, luminance, luminance, 1.0);
+}
+
+technique Draw
+{
+  pass
+  {
+    vertex_shader = VSDefault(v_in);
+    pixel_shader  = PSLuminanceExtraction(v_in);
+  }
+}

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -1,2 +1,7 @@
 showdrawName="Show Draw"
 sensitivityFactorDb="Sensitivity Factor [dB]"
+
+extractionMode="Extraction Mode"
+extractionModeDefault="Default"
+extractionModePassthrough="Passthrough"
+extractionModeLuminanceExtraction="Luminance Extraction"

--- a/src/plugin-main.c
+++ b/src/plugin-main.c
@@ -32,8 +32,20 @@ const char *showdraw_get_name(void *type_data)
 
 #define MAX_PREVIOUS_TEXTURES 15
 
+#define EXTRACTION_MODE_DEFAULT 0
+#define EXTRACTION_MODE_PASSTHROUGH 1
+#define EXTRACTION_MODE_LUMINANCE_EXTRACTION 2
+
 struct showdraw_filter_context {
 	obs_source_t *filter;
+
+	long long extraction_mode;
+
+	const char *luminance_extraction_effect_path;
+	const char *luminance_extraction_effect_tech;
+	gs_effect_t *luminance_extraction_effect;
+	gs_eparam_t *luminance_extraction_effect_texel_height;
+	gs_eparam_t *luminance_extraction_effect_texel_width;
 
 	const char *effect_path;
 	const char *effect_tech;
@@ -57,6 +69,13 @@ void *showdraw_create(obs_data_t *settings, obs_source_t *source)
 
 	context->filter = source;
 
+	context->luminance_extraction_effect_path = obs_module_file("effects/luminance-extraction.effect");
+	context->luminance_extraction_effect_tech = "Draw";
+
+	context->luminance_extraction_effect = NULL;
+	context->luminance_extraction_effect_texel_height = NULL;
+	context->luminance_extraction_effect_texel_width = NULL;
+
 	context->effect_path = obs_module_file("effects/drawing-emphasizer.effect");
 	context->effect_tech = "Draw";
 	context->sensitivity_factor = 0.0f;
@@ -77,6 +96,11 @@ void showdraw_destroy(void *data)
 
 	struct showdraw_filter_context *context = (struct showdraw_filter_context *)data;
 
+	if (context->luminance_extraction_effect) {
+		gs_effect_destroy(context->luminance_extraction_effect);
+		context->luminance_extraction_effect = NULL;
+	}
+
 	if (context->effect) {
 		gs_effect_destroy(context->effect);
 		context->effect = NULL;
@@ -89,6 +113,7 @@ void showdraw_get_defaults(obs_data_t *data)
 {
 	obs_data_set_default_double(data, "sensitivityFactorDb", 0.0);
 	obs_data_set_default_string(data, "effectTechnique", "Draw");
+	obs_data_set_default_int(data, "extractionMode", EXTRACTION_MODE_DEFAULT);
 }
 
 obs_properties_t *showdraw_get_properties(void *data)
@@ -105,6 +130,16 @@ obs_properties_t *showdraw_get_properties(void *data)
 								      OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_STRING);
 	obs_property_list_add_string(propEffectTechnique, "Default", "Draw");
 
+	obs_property_t *propExtractionMode = obs_properties_add_list(props, "extractionMode",
+								     obs_module_text("extractionMode"),
+								     OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+	obs_property_list_add_int(propExtractionMode, obs_module_text("extractionModeDefault"),
+				  EXTRACTION_MODE_DEFAULT);
+	obs_property_list_add_int(propExtractionMode, obs_module_text("extractionModePassthrough"),
+				  EXTRACTION_MODE_PASSTHROUGH);
+	obs_property_list_add_int(propExtractionMode, obs_module_text("extractionModeLuminanceExtraction"),
+				  EXTRACTION_MODE_LUMINANCE_EXTRACTION);
+
 	return props;
 }
 
@@ -114,6 +149,7 @@ void showdraw_update(void *data, obs_data_t *settings)
 
 	context->sensitivity_factor = (float)pow(10.0, obs_data_get_double(settings, "sensitivityFactorDb") / 10.0);
 	context->effect_tech = obs_data_get_string(settings, "effectTechnique");
+	context->extraction_mode = obs_data_get_int(settings, "extractionMode");
 }
 
 void showdraw_video_render(void *data, gs_effect_t *effect)
@@ -128,6 +164,26 @@ void showdraw_video_render(void *data, gs_effect_t *effect)
 		obs_log(LOG_ERROR, "Target source not found");
 		obs_source_skip_video_filter(context->filter);
 		return;
+	}
+
+	if (!context->luminance_extraction_effect) {
+		char *error_string = NULL;
+
+		gs_effect_t *luminance_extraction_effect =
+			gs_effect_create_from_file(context->luminance_extraction_effect_path, &error_string);
+		if (!luminance_extraction_effect) {
+			obs_log(LOG_ERROR, "Error loading luminance extraction effect: %s", error_string);
+			bfree(error_string);
+			return;
+		}
+
+		context->luminance_extraction_effect = luminance_extraction_effect;
+		context->luminance_extraction_effect_texel_width =
+			gs_effect_get_param_by_name(context->luminance_extraction_effect, "texelWidth");
+		context->luminance_extraction_effect_texel_height =
+			gs_effect_get_param_by_name(context->luminance_extraction_effect, "texelHeight");
+
+		obs_log(LOG_INFO, "Luminance extraction effect loaded successfully");
 	}
 
 	if (!context->effect) {
@@ -148,17 +204,24 @@ void showdraw_video_render(void *data, gs_effect_t *effect)
 		obs_log(LOG_INFO, "Effect loaded successfully");
 	}
 
+	long long extractionMode = context->extraction_mode == EXTRACTION_MODE_DEFAULT ? EXTRACTION_MODE_PASSTHROUGH
+										       : context->extraction_mode;
+
+	if (extractionMode <= EXTRACTION_MODE_PASSTHROUGH) {
+		obs_source_skip_video_filter(context->filter);
+		return;
+	}
+
 	if (!obs_source_process_filter_begin(context->filter, GS_RGBA, OBS_ALLOW_DIRECT_RENDERING)) {
 		obs_log(LOG_ERROR, "Could not begin filter processing");
 		obs_source_skip_video_filter(context->filter);
 		return;
 	}
 
-	gs_effect_set_float(context->effect_texel_width, 1.0f / (float)obs_source_get_base_width(target));
-	gs_effect_set_float(context->effect_texel_height, 1.0f / (float)obs_source_get_base_width(target));
-	gs_effect_set_float(context->effect_sensitivity_factor, context->sensitivity_factor);
+	gs_effect_set_float(context->luminance_extraction_effect_texel_width, 1.0f / (float)obs_source_get_base_width(target));
+	gs_effect_set_float(context->luminance_extraction_effect_texel_height, 1.0f / (float)obs_source_get_base_height(target));
 
-	obs_source_process_filter_tech_end(context->filter, context->effect, 0, 0, context->effect_tech);
+	obs_source_process_filter_tech_end(context->filter, context->luminance_extraction_effect, 0, 0, context->effect_tech);
 }
 
 struct obs_source_info showdraw_filter = {


### PR DESCRIPTION
This pull request introduces a new "Luminance Extraction" mode to the showdraw filter plugin, allowing users to extract luminance information from video frames. It adds support for selecting the extraction mode via the plugin UI, implements the luminance extraction effect, and updates the filter logic to process frames accordingly. The changes are grouped below by theme.

### Feature: Luminance Extraction Mode

* Added a new effect file `luminance-extraction.effect` that implements a vertex and pixel shader for luminance extraction.
* Updated the filter context structure in `plugin-main.c` to support the new extraction mode and store luminance extraction effect resources.
* Implemented loading, initialization, and destruction logic for the luminance extraction effect in the filter lifecycle functions. [[1]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R72-R78) [[2]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R99-R103)
* Modified the video render function to select and process the correct extraction mode, including skipping processing for passthrough and using the luminance extraction effect when selected. [[1]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R169-R188) [[2]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R207-R224)

### UI/Config Updates

* Added a new `extractionMode` property to the plugin configuration, including localization strings and UI property list for mode selection. [[1]](diffhunk://#diff-b3c242ee2d502c9e6dade4bace60d2ea2ab52969dd96b1cac4ed42f60668b18aR3-R7) [[2]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R116) [[3]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R133-R142) [[4]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R152)

### Minor Code Refactor

* Reordered uniforms in `drawing-emphasizer.effect` for consistency.Introduces a new luminance extraction effect and integrates it into the plugin. Adds an 'Extraction Mode' property to the filter, updates localization, and refactors video rendering to support the new mode. Effect loading and resource management are updated accordingly.