### PR TITLE
Scaling

### DIFF
--- a/data/effects/drawing-emphasizer.effect
+++ b/data/effects/drawing-emphasizer.effect
@@ -12,7 +12,8 @@ uniform texture2d motionMap;
 uniform float strength;
 uniform float motionThreshold;
 
-uniform float gain;
+// Scaling parameters
+uniform float scalingFactor;
 
 sampler_state def_sampler {
 	Filter   = Linear;
@@ -242,6 +243,11 @@ float4 PSDilation(VertInOut vert_in) : TARGET
 	return float4(max_val, max_val, max_val, 1.0);
 }
 
+float4 PSScaling(VertInOut vert_in) : TARGET
+{
+	return float4(image.Sample(def_sampler, vert_in.uv).rgb * scalingFactor, 1.0);
+}
+
 technique Draw
 {
 	pass
@@ -311,5 +317,14 @@ technique Dilation
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDilation(vert_in);
+	}
+}
+
+technique Scaling
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSScaling(vert_in);
 	}
 }

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -5,6 +5,7 @@ extractionModeDefault="Default"
 extractionModePassthrough="Passthrough"
 extractionModeLuminanceExtraction="Luminance Extraction"
 extractionModeEdgeDetection="Edge Detection"
+extractionModeScaling="Scaling"
 
 medianFilteringGroup="Median Filtering"
 medianFilteringKernelSize="Median Filtering Kernel Size"
@@ -29,3 +30,5 @@ morphologyOpeningDilationKernelSize="Morphology Opening Dilation Kernel Size"
 
 morphologyClosingErosionKernelSize="Morphology Closing Erosion Kernel Size"
 morphologyClosingDilationKernelSize="Morphology Closing Dilation Kernel Size"
+
+scalingFactor="Scaling Factor [dB]"

--- a/src/plugin-main.c
+++ b/src/plugin-main.c
@@ -38,7 +38,7 @@ const char *showdraw_get_name(void *type_data)
 #define EXTRACTION_MODE_EDGE_DETECTION 300
 #define EXTRACTION_MODE_SCALING 400
 
-#define EXTRACTION_MODE_DEFAULT_VALUE EXTRACTION_MODE_EDGE_DETECTION
+#define EXTRACTION_MODE_DEFAULT_VALUE EXTRACTION_MODE_SCALING
 
 struct showdraw_filter_context {
 	obs_source_t *filter;


### PR DESCRIPTION
This pull request introduces a new "Scaling" extraction mode to the drawing-emphasizer plugin, enabling users to apply a configurable scaling factor to the image processing pipeline. The implementation includes shader changes, plugin code updates, and UI/locale enhancements for user control and feedback. Additionally, the codebase is refactored to remove unused gain parameters and improve resource management.

**Feature Addition – Scaling Extraction Mode:**

* Added a new extraction mode, `EXTRACTION_MODE_SCALING`, with corresponding shader technique (`Scaling`) and pixel shader (`PSScaling`) in `drawing-emphasizer.effect`. This mode multiplies image RGB values by a user-defined scaling factor. [[1]](diffhunk://#diff-05157fc92688c38364b7b0a3a564ca7ee970d2d1e89961c0d0c102608b19c2fcL15-R16) [[2]](diffhunk://#diff-05157fc92688c38364b7b0a3a564ca7ee970d2d1e89961c0d0c102608b19c2fcR246-R250) [[3]](diffhunk://#diff-05157fc92688c38364b7b0a3a564ca7ee970d2d1e89961c0d0c102608b19c2fcR322-R330) [[4]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R39-R41) [[5]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R93) [[6]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R359) [[7]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R645-R663)

* Introduced a new property, `scalingFactorDb`, in the plugin settings and UI, allowing users to adjust the scaling factor in decibels via a slider. The corresponding locale strings are added for clarity. [[1]](diffhunk://#diff-b3c242ee2d502c9e6dade4bace60d2ea2ab52969dd96b1cac4ed42f60668b18aR8) [[2]](diffhunk://#diff-b3c242ee2d502c9e6dade4bace60d2ea2ab52969dd96b1cac4ed42f60668b18aR33-R34) [[3]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R217-R218) [[4]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R275-R276)

**Code Refactoring and Cleanup:**

* Removed the unused `gain` parameter from both the shader and plugin code, cleaning up related effect parameter handling. [[1]](diffhunk://#diff-05157fc92688c38364b7b0a3a564ca7ee970d2d1e89961c0d0c102608b19c2fcL15-R16) [[2]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7L76-R84) [[3]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7L133-R145) [[4]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7L305-R348)

* Improved resource management by ensuring destroyed textures are set to `NULL` and freeing the effect path string properly, preventing potential memory leaks. [[1]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R167) [[2]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R188-R197) [[3]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R377) [[4]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R391) [[5]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R405) [[6]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R420)

**Default Behavior and Parameter Initialization:**

* Changed the default extraction mode to "Scaling" and initialized the scaling factor to 1.0, ensuring consistent startup behavior. [[1]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R39-R41) [[2]](diffhunk://#diff-b7e45146adb30b86669fd1f645e0d58906c10d5ef52a941cec04867b4d87ddb7R122-R123)

**Processing Logic Updates:**

* Updated the video render function to process the new scaling mode, including setting the scaling factor parameter, executing the scaling technique, and swapping textures appropriately.

**Miscellaneous Improvements:**

* Corrected texture swap logic for motion-adaptive filtering to ensure proper image history handling.

These changes collectively add a new image scaling feature, improve plugin flexibility, and enhance code reliability.