### PR TITLE
Add Canny hysteresis edge detection support

### DIFF
--- a/data/effects/drawing.effect
+++ b/data/effects/drawing.effect
@@ -12,6 +12,10 @@ uniform texture2d motionMap;
 uniform float strength;
 uniform float motionThreshold;
 
+// Canny edge detection parameters
+uniform float highThreshold;
+uniform float lowThreshold;
+
 // Scaling parameters
 uniform float scalingFactor;
 
@@ -241,28 +245,52 @@ float4 PSSuppressNonMaximum(VertInOut vert_in) : TARGET
 	return float4(encoded_magnitude, encoded_magnitude, encoded_magnitude, 1.0f);
 }
 
-float4 PSDetectEdge(VertInOut vert_in) : TARGET
+float4 PSHysteresisClassify(VertInOut vert_in) : TARGET
+{
+	float encoded_magnitude = image.Sample(def_sampler, vert_in.uv).r;
+
+	if (encoded_magnitude >= highThreshold / SQRT_20) {
+		return float4(1.0, 1.0, 1.0, 1.0);
+	} else if (encoded_magnitude >= lowThreshold / SQRT_20) {
+		return float4(0.5, 0.5, 0.5, 1.0);
+	} else {
+		return float4(0.0, 0.0, 0.0, 1.0);
+	}
+}
+
+float4 PSHysteresisPropagate(VertInOut vert_in) : TARGET
 {
 	float2 texel_size = float2(texelWidth, texelHeight);
 	float2 uv = vert_in.uv;
 
-	float lum[9];
-	lum[0] = image.Sample(def_sampler, uv + texel_size * float2(-1.0, -1.0)).r;
-	lum[1] = image.Sample(def_sampler, uv + texel_size * float2( 0.0, -1.0)).r;
-	lum[2] = image.Sample(def_sampler, uv + texel_size * float2( 1.0, -1.0)).r;
-	lum[3] = image.Sample(def_sampler, uv + texel_size * float2(-1.0,  0.0)).r;
-	lum[4] = image.Sample(def_sampler, uv).r;
-	lum[5] = image.Sample(def_sampler, uv + texel_size * float2( 1.0,  0.0)).r;
-	lum[6] = image.Sample(def_sampler, uv + texel_size * float2(-1.0,  1.0)).r;
-	lum[7] = image.Sample(def_sampler, uv + texel_size * float2( 0.0,  1.0)).r;
-	lum[8] = image.Sample(def_sampler, uv + texel_size * float2( 1.0,  1.0)).r;
+	float center_val = image.Sample(def_sampler, uv).r;
 
-	float sobel_x = -lum[0] - 2.0 * lum[3] - lum[6] + lum[2] + 2.0 * lum[5] + lum[8];
-	float sobel_y = -lum[0] - 2.0 * lum[1] - lum[2] + lum[6] + 2.0 * lum[7] + lum[8];
+	if (center_val < 0.5f || center_val == 1.0f) {
+		return float4(center_val, center_val, center_val, 1.0f);
+	}
 
-	float edge = sqrt(sobel_x * sobel_x + sobel_y * sobel_y);
+	for (int y = -1; y <= 1; y++) {
+		for (int x = -1; x <= 1; x++) {
+			if (x == 0 && y == 0) continue;
+			float neighbor_val = image.Sample(def_sampler, uv + texel_size * float2(x, y)).r;
+		        if (neighbor_val == 1.0f) {
+        			return float4(1.0, 1.0, 1.0, 1.0);
+        		}
+		}
+	}
+    
+	return float4(center_val, center_val, center_val, 1.0f);
+}
 
-	return float4(edge, edge, edge, 1.0);
+float4 PSHysteresisFinalize(VertInOut vert_in) : TARGET
+{
+	float val = image.Sample(def_sampler, vert_in.uv).r;
+    
+	if (val < 1.0f) {
+		return float4(0.0f, 0.0f, 0.0f, 1.0f);
+	}
+
+	return float4(1.0f, 1.0f, 1.0f, 1.0f);
 }
 
 float4 PSErosion(VertInOut vert_in) : TARGET
@@ -373,12 +401,30 @@ technique SuppressNonMaximum
 	}
 }
 
-technique DetectEdge
+technique HysteresisClassify
 {
 	pass
 	{
 		vertex_shader = VSDefault(vert_in);
-		pixel_shader  = PSDetectEdge(vert_in);
+		pixel_shader  = PSHysteresisClassify(vert_in);
+	}
+}
+
+technique HysteresisPropagate
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSHysteresisPropagate(vert_in);
+	}
+}
+
+technique HysteresisFinalize
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSHysteresisFinalize(vert_in);
 	}
 }
 

--- a/src/DrawingEffect.hpp
+++ b/src/DrawingEffect.hpp
@@ -22,10 +22,8 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 class DrawingEffect {
 public:
-	DrawingEffect();
-	~DrawingEffect();
-
-	bool init();
+	DrawingEffect(void);
+	~DrawingEffect(void) noexcept;
 
 	gs_effect_t *effect = nullptr;
 
@@ -40,6 +38,9 @@ public:
 	gs_eparam_t *float_strength = nullptr;
 	gs_eparam_t *float_motion_threshold = nullptr;
 
+	gs_eparam_t *float_high_threshold = nullptr;
+	gs_eparam_t *float_low_threshold = nullptr;
+
 	gs_eparam_t *float_scaling_factor = nullptr;
 
 	gs_technique_t *tech_draw = nullptr;
@@ -49,7 +50,9 @@ public:
 	gs_technique_t *tech_motion_adaptive_filtering = nullptr;
 	gs_technique_t *tech_apply_sobel = nullptr;
 	gs_technique_t *tech_suppress_non_maximum = nullptr;
-	gs_technique_t *tech_detect_edge = nullptr;
+	gs_technique_t *tech_hysteresis_classify = nullptr;
+	gs_technique_t *tech_hysteresis_propagate = nullptr;
+	gs_technique_t *tech_hysteresis_finalize = nullptr;
 	gs_technique_t *tech_erosion = nullptr;
 	gs_technique_t *tech_dilation = nullptr;
 	gs_technique_t *tech_scaling = nullptr;

--- a/src/Preset.cpp
+++ b/src/Preset.cpp
@@ -17,6 +17,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 */
 
 #include <chrono>
+#include <cmath>
 #include <ctime>
 #include <filesystem>
 #include <iomanip>
@@ -54,6 +55,8 @@ obs_data_t *Preset::loadIntoObsData(obs_data_t *data) const noexcept
 	obs_data_set_int(data, "motionMapKernelSize", motionMapKernelSize);
 	obs_data_set_double(data, "motionAdaptiveFilteringStrength", motionAdaptiveFilteringStrength);
 	obs_data_set_double(data, "motionAdaptiveFilteringMotionThreshold", motionAdaptiveFilteringMotionThreshold);
+	obs_data_set_double(data, "hysteresisHighThreshold", hysteresisHighThreshold);
+	obs_data_set_double(data, "hysteresisLowThreshold", hysteresisLowThreshold);
 	obs_data_set_int(data, "morphologyOpeningErosionKernelSize", morphologyOpeningErosionKernelSize);
 	obs_data_set_int(data, "morphologyOpeningDilationKernelSize", morphologyOpeningDilationKernelSize);
 	obs_data_set_int(data, "morphologyClosingErosionKernelSize", morphologyClosingErosionKernelSize);
@@ -105,6 +108,14 @@ std::optional<std::string> Preset::validate(void) const noexcept
 		return obs_module_text("configHelperInvalidMotionAdaptiveFilteringMotionThreshold");
 	}
 
+	if (hysteresisHighThreshold < 0.0 || hysteresisHighThreshold > std::sqrt(20.0)) {
+		return obs_module_text("configHelperInvalidHysteresisHighThreshold");
+	}
+
+	if (hysteresisLowThreshold < 0.0 || hysteresisLowThreshold > std::sqrt(20.0)) {
+		return obs_module_text("configHelperInvalidHysteresisLowThreshold");
+	}
+
 	if (morphologyOpeningErosionKernelSize < 1 || morphologyOpeningErosionKernelSize > 31 ||
 	    morphologyOpeningErosionKernelSize % 2 == 0) {
 		return obs_module_text("configHelperInvalidMorphologyOpeningErosionKernelSize");
@@ -141,6 +152,8 @@ Preset Preset::fromObsData(obs_data_t *data) noexcept
 		obs_data_get_int(data, "motionMapKernelSize"),
 		obs_data_get_double(data, "motionAdaptiveFilteringStrength"),
 		obs_data_get_double(data, "motionAdaptiveFilteringMotionThreshold"),
+		obs_data_get_double(data, "hysteresisHighThreshold"),
+		obs_data_get_double(data, "hysteresisLowThreshold"),
 		obs_data_get_int(data, "morphologyOpeningErosionKernelSize"),
 		obs_data_get_int(data, "morphologyOpeningDilationKernelSize"),
 		obs_data_get_int(data, "morphologyClosingDilationKernelSize"),
@@ -226,6 +239,8 @@ Preset Preset::getStrongDefault(void) noexcept
 		3,                       // motionMapKernelSize
 		0.5,                     // motionAdaptiveFilteringStrength
 		0.3,                     // motionAdaptiveFilteringMotionThreshold
+		0.2,                     // hysteresisHighThreshold
+		0.1,                     // hysteresisLowThreshold
 		1,                       // morphologyOpeningErosionKernelSize
 		1,                       // morphologyOpeningDilationKernelSize
 		7,                       // morphologyClosingDilationKernelSize

--- a/src/Preset.hpp
+++ b/src/Preset.hpp
@@ -46,6 +46,9 @@ public:
 	double motionAdaptiveFilteringStrength;
 	double motionAdaptiveFilteringMotionThreshold;
 
+	double hysteresisHighThreshold;
+	double hysteresisLowThreshold;
+
 	std::int64_t morphologyOpeningErosionKernelSize;
 	std::int64_t morphologyOpeningDilationKernelSize;
 

--- a/src/ShowDrawFilterContext.hpp
+++ b/src/ShowDrawFilterContext.hpp
@@ -56,7 +56,6 @@ public:
 	void videoRender(void) noexcept;
 
 private:
-	bool initEffect(void) noexcept;
 	bool ensureTextures(uint32_t width, uint32_t height) noexcept;
 
 	void applyLuminanceExtractionPass(void) noexcept;
@@ -64,7 +63,9 @@ private:
 	void applyMotionAdaptiveFilteringPass(const float texelWidth, const float texelHeight) noexcept;
 	void applySobelPass(const float texelWidth, const float texelHeight) noexcept;
 	void applySuppressNonMaximumPass(const float texelWidth, const float texelHeight) noexcept;
-	void applyEdgeDetectionPass(const float texelWidth, const float texelHeight) noexcept;
+	void applyHysteresisClassifyPass(const float texelWidth, const float texelHeight, const float highThreshold, const float lowThreshold) noexcept;
+	void applyHysteresisPropagatePass(const float texelWidth, const float texelHeight) noexcept;
+	void applyHysteresisFinalizePass(const float texelWidth, const float texelHeight) noexcept;
 	void applyMorphologyPass(const float texelWidth, const float texelHeight, gs_technique_t *technique,
 				 int kernelSize) noexcept;
 	void applyScalingPass(void) noexcept;
@@ -72,6 +73,7 @@ private:
 
 	obs_data_t *settings;
 	obs_source_t *filter;
+	std::unique_ptr<DrawingEffect> drawingEffect;
 	Preset runningPreset;
 
 	double scaling_factor;
@@ -81,7 +83,6 @@ private:
 	gs_texture_t *texture_motion_map;
 	gs_texture_t *texture_previous_luminance;
 
-	std::unique_ptr<DrawingEffect> drawingEffect;
 };
 
 #endif


### PR DESCRIPTION
This pull request introduces a full implementation of Canny edge detection hysteresis thresholding to the drawing effect pipeline, replacing the previous single-pass edge detection. The changes add new configurable parameters for hysteresis thresholds, update the shader and C++ code to support multi-pass hysteresis processing, and refactor effect initialization for better error handling. User-facing configuration and validation are also extended to support the new hysteresis features.

### Canny Edge Detection Hysteresis Implementation

* Added new shader passes (`PSHysteresisClassify`, `PSHysteresisPropagate`, `PSHysteresisFinalize`) and corresponding techniques in `drawing.effect`, replacing the old `DetectEdge` pass. These passes implement the three-stage hysteresis thresholding required for Canny edge detection. [[1]](diffhunk://#diff-539a1483e7234ad83336c5dfd1ab07ec4032417b7be15bc3713c07587f18fca8L244-R293) [[2]](diffhunk://#diff-539a1483e7234ad83336c5dfd1ab07ec4032417b7be15bc3713c07587f18fca8L376-R427)
* Introduced new uniform parameters (`highThreshold`, `lowThreshold`) in the shader for configuring hysteresis thresholds.

### Effect Initialization and Refactoring

* Refactored `DrawingEffect` initialization: now throws exceptions on failure instead of returning bool, and effect destruction is handled in the destructor. Updated member variables and removed the obsolete `init()` method. [[1]](diffhunk://#diff-3ebb0bd9d64e6947d5c1876726057b8e0500ad2aa3cc427619a36271fa5bed47L29-L37) [[2]](diffhunk://#diff-3ebb0bd9d64e6947d5c1876726057b8e0500ad2aa3cc427619a36271fa5bed47L62-R69) [[3]](diffhunk://#diff-3ebb0bd9d64e6947d5c1876726057b8e0500ad2aa3cc427619a36271fa5bed47L100-R112) [[4]](diffhunk://#diff-b23aa528fb78a552962df17ea946bec5c0dbdceb6c0920bde20e661ea1974b15L25-R26)
* Updated effect parameter and technique member variables to support new hysteresis stages. [[1]](diffhunk://#diff-3ebb0bd9d64e6947d5c1876726057b8e0500ad2aa3cc427619a36271fa5bed47R84-R86) [[2]](diffhunk://#diff-b23aa528fb78a552962df17ea946bec5c0dbdceb6c0920bde20e661ea1974b15R41-R43) [[3]](diffhunk://#diff-b23aa528fb78a552962df17ea946bec5c0dbdceb6c0920bde20e661ea1974b15L52-R55)

### Pipeline Integration

* Replaced the edge detection pass in `ShowDrawFilterContext` with a multi-pass hysteresis pipeline: classify, propagate (8 iterations), and finalize. Updated all related method calls and swapped out old edge detection logic. [[1]](diffhunk://#diff-dbe7df09cd8faf4fe110b9f57ca49d0f9e15313542b40de39b3596a23ad941f3L402-R429) [[2]](diffhunk://#diff-dbe7df09cd8faf4fe110b9f57ca49d0f9e15313542b40de39b3596a23ad941f3L411-R452) [[3]](diffhunk://#diff-dbe7df09cd8faf4fe110b9f57ca49d0f9e15313542b40de39b3596a23ad941f3R586-R593)
* Updated effect creation and error handling logic in `videoRender` for robustness. [[1]](diffhunk://#diff-dbe7df09cd8faf4fe110b9f57ca49d0f9e15313542b40de39b3596a23ad941f3L475-R520) [[2]](diffhunk://#diff-dbe7df09cd8faf4fe110b9f57ca49d0f9e15313542b40de39b3596a23ad941f3L257-L261) [[3]](diffhunk://#diff-dbe7df09cd8faf4fe110b9f57ca49d0f9e15313542b40de39b3596a23ad941f3R127) [[4]](diffhunk://#diff-dbe7df09cd8faf4fe110b9f57ca49d0f9e15313542b40de39b3596a23ad941f3L113-R113)

### Configuration and Validation

* Added hysteresis threshold parameters to the preset system (`Preset` struct, config loading/saving, validation, and defaults). [[1]](diffhunk://#diff-db9241ee18be4160fe14f7f31a6f7a3c75599a9adc1eeb9692674c69c33a7b81R49-R51) [[2]](diffhunk://#diff-f90646f3c5ed485c17a05b410f45be12ccf17fec307ab5428be67b1c5179ae50R58-R59) [[3]](diffhunk://#diff-f90646f3c5ed485c17a05b410f45be12ccf17fec307ab5428be67b1c5179ae50R155-R156) [[4]](diffhunk://#diff-f90646f3c5ed485c17a05b410f45be12ccf17fec307ab5428be67b1c5179ae50R242-R243) [[5]](diffhunk://#diff-f90646f3c5ed485c17a05b410f45be12ccf17fec307ab5428be67b1c5179ae50R111-R118)
* Updated filter context to expose hysteresis threshold sliders in the OBS UI, with appropriate validation and default values. [[1]](diffhunk://#diff-dbe7df09cd8faf4fe110b9f57ca49d0f9e15313542b40de39b3596a23ad941f3R222-R226) [[2]](diffhunk://#diff-dbe7df09cd8faf4fe110b9f57ca49d0f9e15313542b40de39b3596a23ad941f3R150-R154) [[3]](diffhunk://#diff-dbe7df09cd8faf4fe110b9f57ca49d0f9e15313542b40de39b3596a23ad941f3R255-R259)

### Minor Improvements

* Included `<cmath>` for mathematical operations and cleaned up unused code.

Let me know if you'd like a deeper explanation of how the hysteresis passes work or how the configuration is wired through the pipeline!Introduces Canny edge detection hysteresis steps to the drawing effect, including new shader techniques and parameters for high/low thresholds. Updates Preset and ShowDrawFilterContext to support configuration, validation, and application of hysteresis passes. Refactors DrawingEffect initialization and resource management for improved error handling and lifecycle control.