### PR TITLE
Test windows

### DIFF
--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -8,13 +8,13 @@ on:
     branches:
       - "main"
 
-defaults:
-  run:
-    shell: "bash"
-
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
+
+defaults:
+  run:
+    shell: "bash"
 
 permissions:
   contents: "read"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -52,7 +52,10 @@ jobs:
 
     steps:
       - name: "Install obs-studio.install"
-        run: "choco install obs-studio.install -y --no-progress"
+        run: |
+          choco install obs-studio.install -y --no-progress
+          echo "$env:ProgramFiles\obs-studio\bin\64bit" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: "pwsh"
 
       - name: "Checkout"
         uses: "actions/checkout@v4"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -51,8 +51,8 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: "Install OBS.app"
-        run: "choco install obs-studio.install"
+      - name: "Install obs-studio.install"
+        run: "choco install obs-studio.install -y --no-progress"
 
       - name: "Checkout"
         uses: "actions/checkout@v4"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -58,10 +58,10 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Configure for CI Testing"
-        run: "cmake --preset windows-x64-testing-ci"
+        run: "cmake --preset windows-testing-ci-x64"
 
       - name: "Build for CI Testing"
-        run: "cmake --build --preset windows-x64-testing-ci"
+        run: "cmake --build --preset windows-testing-ci-x64"
 
       - name: "Run tests"
-        run: "ctest --preset windows-x64-testing-ci"
+        run: "ctest --preset windows-testing-ci-x64"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -58,10 +58,10 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Configure for CI Testing"
-        run: "cmake --preset windows-testing-ci"
+        run: "cmake --preset windows-x64-testing-ci"
 
       - name: "Build for CI Testing"
-        run: "cmake --build --preset windows-testing-ci"
+        run: "cmake --build --preset windows-x64-testing-ci"
 
       - name: "Run tests"
-        run: "ctest --preset windows-testing-ci"
+        run: "ctest --preset windows-x64-testing-ci"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -42,3 +42,26 @@ jobs:
 
       - name: "Run tests"
         run: "ctest --preset macos-testing-ci"
+
+  RunTestsOnWindows:
+    name: "Run Tests on Windows"
+
+    runs-on: "windows-2022"
+
+    timeout-minutes: 30
+
+    steps:
+      - name: "Install OBS.app"
+        run: "winget install obs-studio"
+
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Configure for CI Testing"
+        run: "cmake --preset macos-testing-ci"
+
+      - name: "Build for CI Testing"
+        run: "cmake --build --preset macos-testing-ci"
+
+      - name: "Run tests"
+        run: "ctest --preset macos-testing-ci"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: "Install OBS.app"
-        run: "winget install obs-studio"
+        run: "choco install obs-studio.install"
 
       - name: "Checkout"
         uses: "actions/checkout@v4"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -58,10 +58,10 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Configure for CI Testing"
-        run: "cmake --preset macos-testing-ci"
+        run: "cmake --preset windows-testing-ci"
 
       - name: "Build for CI Testing"
-        run: "cmake --build --preset macos-testing-ci"
+        run: "cmake --build --preset windows-testing-ci"
 
       - name: "Run tests"
-        run: "ctest --preset macos-testing-ci"
+        run: "ctest --preset windows-testing-ci"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -93,6 +93,28 @@
       }
     },
     {
+      "name": "windows-x64-testing",
+      "inherits": ["windows-x64"],
+      "displayName": "Windows x64 Testing build",
+      "description": "Build for Windows x64 for Testing",
+      "binaryDir": "${sourceDir}/build_x64_testing",
+      "generator": "Visual Studio 17 2022",
+      "cacheVariables": {
+        "BUILD_TESTING": true
+      }
+    },
+    {
+      "name": "windows-x64-testing-ci",
+      "inherits": ["windows-x64-testing"],
+      "displayName": "Windows x64 Testing CI build",
+      "description": "Build for Windows x64 for CI Testing",
+      "generator": "Visual Studio 17 2022",
+      "cacheVariables": {
+        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
+        "ENABLE_CCACHE": true
+      }
+    },
+    {
       "name": "ubuntu-x86_64",
       "displayName": "Ubuntu x86_64",
       "description": "Build for Ubuntu x86_64",
@@ -189,6 +211,16 @@
     {
       "name": "macos-testing-ci",
       "configurePreset": "macos-testing-ci",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "windows-x64-testing",
+      "configurePreset": "windows-x64-testing",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "windows-x64-testing-ci",
+      "configurePreset": "windows-x64-testing-ci",
       "configuration": "RelWithDebInfo"
     }
   ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -84,7 +84,7 @@
       "warnings": {"dev": true, "deprecated": true}
     },
     {
-      "name": "windows-x64-ci",
+      "name": "windows-ci-x64",
       "inherits": ["windows-x64"],
       "displayName": "Windows x64 CI build",
       "description": "Build for Windows x64 on CI",
@@ -93,7 +93,7 @@
       }
     },
     {
-      "name": "windows-x64-testing",
+      "name": "windows-testing-x64",
       "inherits": ["windows-x64"],
       "displayName": "Windows x64 Testing build",
       "description": "Build for Windows x64 for Testing",
@@ -104,8 +104,8 @@
       }
     },
     {
-      "name": "windows-x64-testing-ci",
-      "inherits": ["windows-x64-testing"],
+      "name": "windows-testing-ci-x64",
+      "inherits": ["windows-testing-x64"],
       "displayName": "Windows x64 Testing CI build",
       "description": "Build for Windows x64 for CI Testing",
       "generator": "Visual Studio 17 2022",
@@ -214,13 +214,13 @@
       "configuration": "RelWithDebInfo"
     },
     {
-      "name": "windows-x64-testing",
-      "configurePreset": "windows-x64-testing",
+      "name": "windows-testing-x64",
+      "configurePreset": "windows-testing-x64",
       "configuration": "RelWithDebInfo"
     },
     {
-      "name": "windows-x64-testing-ci",
-      "configurePreset": "windows-x64-testing-ci",
+      "name": "windows-testing-ci-x64",
+      "configurePreset": "windows-testing-ci-x64",
       "configuration": "RelWithDebInfo"
     }
   ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -84,7 +84,7 @@
       "warnings": {"dev": true, "deprecated": true}
     },
     {
-      "name": "windows-ci-x64",
+      "name": "windows-x64-ci",
       "inherits": ["windows-x64"],
       "displayName": "Windows x64 CI build",
       "description": "Build for Windows x64 on CI",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -188,6 +188,20 @@
       "configuration": "RelWithDebInfo"
     },
     {
+      "name": "windows-testing-x64",
+      "configurePreset": "windows-x64",
+      "displayName": "Windows x64 Testing",
+      "description": "Windows testing build for x64",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "windows-testing-ci-x64",
+      "configurePreset": "windows-testing-ci-x64",
+      "displayName": "Windows x64 CI Testing",
+      "description": "Windows CI testing build for x64 (RelWithDebInfo configuration)",
+      "configuration": "RelWithDebInfo"
+    },
+    {
       "name": "ubuntu-x86_64",
       "configurePreset": "ubuntu-x86_64",
       "displayName": "Ubuntu x86_64",

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -4,6 +4,7 @@
 - Implementation related to unique_ptr should be placed under bridge.hpp.
 - C and C++ files must be formatted using clang-format-19 after any modification.
 - CMake files must be formatted using gersemi after any modification.
+- OBS team maintains the CMake and GitHub Actions so we don't need to improve these parts.
 
 ## How to build on macOS
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(preset_test test_mock.cpp test_preset.cpp obs_test_environment.cpp)
+add_executable(preset_test test_preset.cpp obs_test_environment.cpp)
 
 if(APPLE)
   set_target_properties(

--- a/tests/obs_test_environment.cpp
+++ b/tests/obs_test_environment.cpp
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
-#include <obs.h>
+#include <obs-module.h>
+
+OBS_DECLARE_MODULE()
+OBS_MODULE_USE_DEFAULT_LOCALE(PLUGIN_NAME, "en-US")
 
 class ObsTestEnvironment : public ::testing::Environment {
 public:

--- a/tests/test_mock.cpp
+++ b/tests/test_mock.cpp
@@ -1,6 +1,0 @@
-#include <obs-module.h>
-
-const char *obs_module_text(const char *key)
-{
-	return key;
-}


### PR DESCRIPTION
This pull request adds support for running CI tests on Windows by introducing new CMake presets and updating the GitHub Actions workflow. The changes ensure that Windows builds are tested in CI, similar to existing macOS workflows. Additionally, the documentation is updated to clarify team responsibilities for maintaining CMake and GitHub Actions.

**CI/CD Workflow Enhancements:**

* Added a new `RunTestsOnWindows` job to the `.github/workflows/push-testing.yaml` file to run tests on Windows using the `windows-2022` runner and install necessary dependencies.

**CMake Preset Additions:**

* Introduced `windows-x64-testing` and `windows-x64-testing-ci` CMake configure presets in `CMakePresets.json` to support Windows x64 builds for testing and CI, including cache variables for testing and compiler warnings as errors.
* Added corresponding build presets for `windows-x64-testing` and `windows-x64-testing-ci` to enable building and testing with the new Windows presets.

**Documentation Update:**

* Updated `GEMINI.md` to clarify that the OBS team maintains CMake and GitHub Actions, so improvement efforts in these areas are not needed.