### PR TITLE
Add Ubuntu CI testing workflow and CMake presets

### DIFF
--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -77,11 +77,11 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: "Install deps"
-        run: ".github/scripts/build-ubuntu --skip-build"
-
       - name: "Checkout"
         uses: "actions/checkout@v4"
+
+      - name: "Install deps"
+        run: ".github/scripts/build-ubuntu --skip-build"
 
       - name: "Configure for CI Testing"
         run: "cmake --preset ubuntu-testing-ci-x86_64"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -77,11 +77,6 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: "Install obs-studio"
-        run: |
-          sudo apt update
-          sudo apt install obs-studio -y --no-install-recommends
-
       - name: "Checkout"
         uses: "actions/checkout@v4"
 

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -41,7 +41,7 @@ jobs:
         run: "cmake --build --preset macos-testing-ci"
 
       - name: "Run tests"
-        run: "ctest --preset macos-testing-ci"
+        run: "ctest --preset macos-testing-ci --rerun-failed --output-on-failure"
 
   RunTestsOnWindows:
     name: "Run Tests on Windows"
@@ -67,7 +67,7 @@ jobs:
         run: "cmake --build --preset windows-testing-ci-x64"
 
       - name: "Run tests"
-        run: "ctest --preset windows-testing-ci-x64"
+        run: "ctest --preset windows-testing-ci-x64 --rerun-failed --output-on-failure"
 
   RunTestsOnUbuntu:
     name: "Run Tests on Ubuntu"
@@ -109,4 +109,4 @@ jobs:
         run: "cmake --build --preset ubuntu-testing-ci-x86_64"
 
       - name: "Run tests"
-        run: "ctest --preset ubuntu-testing-ci-x86_64"
+        run: "ctest --preset ubuntu-testing-ci-x86_64 --rerun-failed --output-on-failure"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -77,11 +77,22 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: "Install obs-studio"
+      - name: "Install dependencies"
         run: |
           sudo add-apt-repository -y ppa:obsproject/obs-studio
           sudo apt update
-          sudo apt-get install -y --no-install-recommends obs-studio
+          sudo apt-get install -y --no-install-recommends \
+            libgles2-mesa-dev \
+            obs-studio \
+            qt6-base-dev \
+            libqt6svg6-dev \
+            qt6-base-private-dev \
+            cmake \
+            ccache \
+            git \
+            jq \
+            ninja-build \
+            pkg-config
 
       - name: "Checkout"
         uses: "actions/checkout@v4"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -77,6 +77,11 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: "Disable man-db update"
+        run: |
+          echo "man-db man-db/auto-update boolean false" | sudo debconf-set-selections
+          sudo apt-get remove --purge -y man-db
+
       - name: "Install dependencies"
         run: |
           sudo add-apt-repository -y ppa:obsproject/obs-studio

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -77,6 +77,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: "Install deps"
+        run: ".github/scripts/build-ubuntu --skip-build"
+
       - name: "Checkout"
         uses: "actions/checkout@v4"
 

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -77,6 +77,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: "Install zsh"
+        run: "sudo apt-get -y --no-install-recommends install zsh"
+
       - name: "Checkout"
         uses: "actions/checkout@v4"
 

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -86,9 +86,6 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@v4"
 
-      - name: "Install deps"
-        run: ".github/scripts/build-ubuntu --skip-build"
-
       - name: "Configure for CI Testing"
         run: "cmake --preset ubuntu-testing-ci-x86_64"
 

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -104,10 +104,7 @@ jobs:
             xvfb
 
       - name: "Start Xvfb"
-        run: |
-          sudo Xvfb $DISPLAY -screen 0 1920x1080x24 +extension Composite &
-          sleep 3
-          xdpyinfo
+        run: "sudo Xvfb $DISPLAY -screen 0 1920x1080x24 +extension Composite &"
 
       - name: "Checkout"
         uses: "actions/checkout@v4"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -76,6 +76,9 @@ jobs:
 
     timeout-minutes: 30
 
+    env:
+      DISPLAY: ":99.0"
+
     steps:
       - name: "Disable man-db update"
         run: |
@@ -97,7 +100,14 @@ jobs:
             git \
             jq \
             ninja-build \
-            pkg-config
+            pkg-config \
+            xvfb
+
+      - name: "Start Xvfb"
+        run: |
+          sudo Xvfb $DISPLAY -screen 0 1920x1080x24 +extension Composite &
+          sleep 3
+          xdpyinfo
 
       - name: "Checkout"
         uses: "actions/checkout@v4"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -68,3 +68,28 @@ jobs:
 
       - name: "Run tests"
         run: "ctest --preset windows-testing-ci-x64"
+
+  RunTestsOnUbuntu:
+    name: "Run Tests on Ubuntu"
+
+    runs-on: "ubuntu-24.04"
+
+    timeout-minutes: 30
+
+    steps:
+      - name: "Install obs-studio"
+        run: |
+          sudo apt update
+          sudo apt install obs-studio -y --no-install-recommends
+
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Configure for CI Testing"
+        run: "cmake --preset ubuntu-testing-ci-x86_64"
+
+      - name: "Build for CI Testing"
+        run: "cmake --build --preset ubuntu-testing-ci-x86_64"
+
+      - name: "Run tests"
+        run: "ctest --preset ubuntu-testing-ci-x86_64"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -77,8 +77,11 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: "Install zsh"
-        run: "sudo apt-get -y --no-install-recommends install zsh"
+      - name: "Install obs-studio"
+        run: |
+          sudo add-apt-repository -y ppa:obsproject/obs-studio
+          sudo apt update
+          sudo apt-get install -y --no-install-recommends obs-studio
 
       - name: "Checkout"
         uses: "actions/checkout@v4"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -164,7 +164,7 @@
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,
         "ENABLE_CCACHE": true
       }
-    },
+    }
   ],
   "buildPresets": [
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -142,7 +142,29 @@
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,
         "ENABLE_CCACHE": true
       }
-    }
+    },
+    {
+      "name": "ubuntu-testing-x86_64",
+      "inherits": ["ubuntu-x86_64"],
+      "displayName": "Ubuntu x86_64 testing build",
+      "description": "Build for Ubuntu x86_64 for Testing",
+      "binaryDir": "${sourceDir}/build_testing_x86_64",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "BUILD_TESTING": true
+      }
+    },
+    {
+      "name": "ubuntu-testing-ci-x86_64",
+      "inherits": ["ubuntu-testing-x86_64"],
+      "displayName": "Ubuntu x86_64 CI Testing build",
+      "description": "Build for Ubuntu x86_64 for CI Testing",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
+        "ENABLE_CCACHE": true
+      }
+    },
   ],
   "buildPresets": [
     {
@@ -214,6 +236,20 @@
       "displayName": "Ubuntu x86_64 CI",
       "description": "Ubuntu CI build for x86_64",
       "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "ubuntu-testing-x86_64",
+      "configurePreset": "ubuntu-x86_64",
+      "displayName": "Ubuntu x86_64 Testing",
+      "description": "Ubuntu testing build for x86_64",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "ubuntu-testing-ci-x86_64",
+      "configurePreset": "ubuntu-testing-ci-x86_64",
+      "displayName": "Ubuntu x86_64 CI Testing",
+      "description": "Ubuntu CI testing build for x86_64",
+      "configuration": "RelWithDebInfo"
     }
   ],
   "testPresets": [
@@ -235,6 +271,16 @@
     {
       "name": "windows-testing-ci-x64",
       "configurePreset": "windows-testing-ci-x64",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "ubuntu-testing-x86_64",
+      "configurePreset": "ubuntu-testing-x86_64",
+      "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "ubuntu-testing-ci-x86_64",
+      "configurePreset": "ubuntu-testing-ci-x86_64",
       "configuration": "RelWithDebInfo"
     }
   ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -110,8 +110,7 @@
       "description": "Build for Windows x64 for CI Testing",
       "generator": "Visual Studio 17 2022",
       "cacheVariables": {
-        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
-        "ENABLE_CCACHE": true
+        "CMAKE_COMPILE_WARNING_AS_ERROR": true
       }
     },
     {


### PR DESCRIPTION
This pull request adds support for running CI tests on Ubuntu alongside existing Windows CI, and introduces new CMake presets for Ubuntu testing. The main changes are the addition of a new GitHub Actions workflow job for Ubuntu and corresponding CMake configuration presets to support testing builds.

**CI Workflow Enhancements:**
* Added a new `RunTestsOnUbuntu` job to `.github/workflows/push-testing.yaml` to run tests on Ubuntu 24.04, including installing `obs-studio`, configuring, building, and running tests using the new Ubuntu testing preset.

**CMake Preset Additions:**
* Introduced new configure, build, and test presets in `CMakePresets.json` for `ubuntu-testing-x86_64` and `ubuntu-testing-ci-x86_64`, enabling targeted testing and CI builds on Ubuntu. [[1]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5R145-R167) [[2]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5R239-R252) [[3]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5R275-R284)Introduces a new GitHub Actions job to run tests on Ubuntu 24.04, including installation of obs-studio and use of new CMake presets for CI testing. Updates CMakePresets.json to add Ubuntu testing and CI testing presets for configuration, build, and test workflows.