### PR TITLE
Update copyright and version information

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
     },
     "name": "obs-showdraw",
     "displayName": "Emphasize drawing on OBS",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "author": "Kaito Udagawa",
     "website": "https://github.com/kaito-tokyo/obs-showdraw",
     "email": "umireon@kaito.tokyo"

--- a/src/plugin-support.c.in
+++ b/src/plugin-support.c.in
@@ -1,6 +1,6 @@
 /*
-Plugin Name
-Copyright (C) <Year> <Developer> <Email Address>
+obs-showdraw
+Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/tests/obs_test_environment.cpp
+++ b/tests/obs_test_environment.cpp
@@ -1,3 +1,21 @@
+/*
+obs-showdraw
+Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
 #include <gtest/gtest.h>
 #include <obs-module.h>
 

--- a/tests/test_preset.cpp
+++ b/tests/test_preset.cpp
@@ -1,3 +1,21 @@
+/*
+obs-showdraw
+Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
 #include <gtest/gtest.h>
 
 #include "Preset.hpp"


### PR DESCRIPTION
This pull request makes minor updates to project metadata and licensing information. The main changes include updating the version number, standardizing the copyright and license headers in the source and test files.

Project metadata update:

* Updated the version number in `buildspec.json` from `1.0.3` to `1.0.4`.

Licensing and copyright:

* Updated the copyright and license header in `src/plugin-support.c.in` to reflect the correct project name, year (2025), author, and email.
* Added the appropriate copyright and license header to `tests/obs_test_environment.cpp`.
* Added the appropriate copyright and license header to `tests/test_preset.cpp`.Updated copyright headers in source and test files to reflect 2025 and correct author information. Bumped version in buildspec.json to 1.0.4.