### PR TITLE
Chack latest impl

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,7 +12,7 @@
       "cacheVariables": {
         "ENABLE_FRONTEND_API": true,
         "ENABLE_QT": true,
-        "BUILD_TESTING": false
+        "BUILD_TESTING": true
       }
     },
     {
@@ -48,28 +48,6 @@
       }
     },
     {
-      "name": "macos-testing",
-      "inherits": ["macos"],
-      "displayName": "macOS Universal Testing build",
-      "description": "Build for macOS 12.0+ (Universal binary) for Testing",
-      "binaryDir": "${sourceDir}/build_macos_testing",
-      "generator": "Xcode",
-      "cacheVariables": {
-        "BUILD_TESTING": true
-      }
-    },
-    {
-      "name": "macos-testing-ci",
-      "inherits": ["macos-testing"],
-      "displayName": "macOS Universal CI build",
-      "description": "Build for macOS 12.0+ (Universal binary) for CI Testing",
-      "generator": "Xcode",
-      "cacheVariables": {
-        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
-        "ENABLE_CCACHE": true
-      }
-    },
-    {
       "name": "windows-x64",
       "displayName": "Windows x64",
       "description": "Build for Windows x64",
@@ -92,27 +70,6 @@
       "inherits": ["windows-x64"],
       "displayName": "Windows x64 CI build",
       "description": "Build for Windows x64 on CI",
-      "cacheVariables": {
-        "CMAKE_COMPILE_WARNING_AS_ERROR": true
-      }
-    },
-    {
-      "name": "windows-testing-x64",
-      "inherits": ["windows-x64"],
-      "displayName": "Windows x64 Testing build",
-      "description": "Build for Windows x64 for Testing",
-      "binaryDir": "${sourceDir}/build_x64_testing",
-      "generator": "Visual Studio 17 2022",
-      "cacheVariables": {
-        "BUILD_TESTING": true
-      }
-    },
-    {
-      "name": "windows-testing-ci-x64",
-      "inherits": ["windows-testing-x64"],
-      "displayName": "Windows x64 Testing CI build",
-      "description": "Build for Windows x64 for CI Testing",
-      "generator": "Visual Studio 17 2022",
       "cacheVariables": {
         "CMAKE_COMPILE_WARNING_AS_ERROR": true
       }
@@ -146,28 +103,6 @@
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,
         "ENABLE_CCACHE": true
       }
-    },
-    {
-      "name": "ubuntu-testing-x86_64",
-      "inherits": ["ubuntu-x86_64"],
-      "displayName": "Ubuntu x86_64 testing build",
-      "description": "Build for Ubuntu x86_64 for Testing",
-      "binaryDir": "${sourceDir}/build_testing_x86_64",
-      "generator": "Ninja",
-      "cacheVariables": {
-        "BUILD_TESTING": true
-      }
-    },
-    {
-      "name": "ubuntu-testing-ci-x86_64",
-      "inherits": ["ubuntu-testing-x86_64"],
-      "displayName": "Ubuntu x86_64 CI Testing build",
-      "description": "Build for Ubuntu x86_64 for CI Testing",
-      "generator": "Ninja",
-      "cacheVariables": {
-        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
-        "ENABLE_CCACHE": true
-      }
     }
   ],
   "buildPresets": [
@@ -186,20 +121,6 @@
       "configuration": "RelWithDebInfo"
     },
     {
-      "name": "macos-testing",
-      "configurePreset": "macos-testing",
-      "displayName": "macOS Universal Testing",
-      "description": "macOS Testing build for Universal architectures",
-      "configuration": "RelWithDebInfo"
-    },
-    {
-      "name": "macos-testing-ci",
-      "configurePreset": "macos-testing-ci",
-      "displayName": "macOS Universal Testing CI",
-      "description": "macOS CI Testing build for Universal architectures",
-      "configuration": "RelWithDebInfo"
-    },
-    {
       "name": "windows-x64",
       "configurePreset": "windows-x64",
       "displayName": "Windows x64",
@@ -214,20 +135,6 @@
       "configuration": "RelWithDebInfo"
     },
     {
-      "name": "windows-testing-x64",
-      "configurePreset": "windows-x64",
-      "displayName": "Windows x64 Testing",
-      "description": "Windows testing build for x64",
-      "configuration": "RelWithDebInfo"
-    },
-    {
-      "name": "windows-testing-ci-x64",
-      "configurePreset": "windows-testing-ci-x64",
-      "displayName": "Windows x64 CI Testing",
-      "description": "Windows CI testing build for x64 (RelWithDebInfo configuration)",
-      "configuration": "RelWithDebInfo"
-    },
-    {
       "name": "ubuntu-x86_64",
       "configurePreset": "ubuntu-x86_64",
       "displayName": "Ubuntu x86_64",
@@ -239,20 +146,6 @@
       "configurePreset": "ubuntu-ci-x86_64",
       "displayName": "Ubuntu x86_64 CI",
       "description": "Ubuntu CI build for x86_64",
-      "configuration": "RelWithDebInfo"
-    },
-    {
-      "name": "ubuntu-testing-x86_64",
-      "configurePreset": "ubuntu-x86_64",
-      "displayName": "Ubuntu x86_64 Testing",
-      "description": "Ubuntu testing build for x86_64",
-      "configuration": "RelWithDebInfo"
-    },
-    {
-      "name": "ubuntu-testing-ci-x86_64",
-      "configurePreset": "ubuntu-testing-ci-x86_64",
-      "displayName": "Ubuntu x86_64 CI Testing",
-      "description": "Ubuntu CI testing build for x86_64",
       "configuration": "RelWithDebInfo"
     }
   ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -151,33 +151,33 @@
   ],
   "testPresets": [
     {
-      "name": "macos-testing",
-      "configurePreset": "macos-testing",
+      "name": "macos",
+      "configurePreset": "macos",
       "configuration": "RelWithDebInfo"
     },
     {
-      "name": "macos-testing-ci",
-      "configurePreset": "macos-testing-ci",
+      "name": "macos-ci",
+      "configurePreset": "macos-ci",
       "configuration": "RelWithDebInfo"
     },
     {
-      "name": "windows-testing-x64",
-      "configurePreset": "windows-testing-x64",
+      "name": "windows-x64",
+      "configurePreset": "windows-x64",
       "configuration": "RelWithDebInfo"
     },
     {
-      "name": "windows-testing-ci-x64",
-      "configurePreset": "windows-testing-ci-x64",
+      "name": "windows-ci-x64",
+      "configurePreset": "windows-ci-x64",
       "configuration": "RelWithDebInfo"
     },
     {
-      "name": "ubuntu-testing-x86_64",
-      "configurePreset": "ubuntu-testing-x86_64",
+      "name": "ubuntu-x86_64",
+      "configurePreset": "ubuntu-x86_64",
       "configuration": "RelWithDebInfo"
     },
     {
-      "name": "ubuntu-testing-ci-x86_64",
-      "configurePreset": "ubuntu-testing-ci-x86_64",
+      "name": "ubuntu-ci-x86_64",
+      "configurePreset": "ubuntu-ci-x86_64",
       "configuration": "RelWithDebInfo"
     }
   ]

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -6,13 +6,8 @@
 - CMake files must be formatted using gersemi after any modification.
 - OBS team maintains the CMake and GitHub Actions so we don't need to improve these parts.
 
-## How to build on macOS
+## How to build and run tests on macOS
 
 1. Run `cmake --preset macos`.
 2. Run `cmake --build --preset macos`.
-
-## How to run tests on macOS
-
-1. Run `cmake --preset macos-testing`.
-2. Run `cmake --build --preset macos-testing`.
-3. Run `ctest --preset macos-testing`.
+3. Run `ctest --preset macos`.

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,7 @@
       "name": "curl",
       "default-features": false
     },
-    "curlpp"
+    "curlpp",
+    "nlohmann-json"
   ]
 }


### PR DESCRIPTION
This pull request simplifies and streamlines the CMake build and test preset configuration, removing redundant testing-specific presets and consolidating testing into the main platform presets. Documentation and dependencies are also updated to reflect these changes.

**CMake preset consolidation and simplification:**

* Removed separate testing and testing-CI build and configure presets for macOS, Windows, and Ubuntu, consolidating testing into the main platform presets (`CMakePresets.json`). [[1]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L50-L71) [[2]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L99-L119) [[3]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L149-L170) [[4]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L188-L201) [[5]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L216-L229) [[6]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L243-R180)
* Updated the main platform presets (`macos`, `windows-x64`, `ubuntu-x86_64`) to enable testing by default by setting `BUILD_TESTING` to `true` (`CMakePresets.json`).
* Updated test presets to use the main platform presets instead of the removed testing-specific presets, simplifying the testing workflow (`CMakePresets.json`).

**Documentation update:**

* Updated `GEMINI.md` to reflect the new unified build and test process on macOS, removing references to the old testing presets and showing the new workflow.

**Dependency update:**

* Added `nlohmann-json` as a dependency in `vcpkg.json`.