### PR TITLE
Update GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,6 +5,7 @@
 - C and C++ files must be formatted using clang-format-19 after any modification.
 - CMake files must be formatted using gersemi after any modification.
 - OBS team maintains the CMake and GitHub Actions so we don't need to improve these parts.
+- The default branch of this project is `main`.
 
 ## How to build and run tests on macOS
 
@@ -14,31 +15,48 @@
 
 ## Release Automation with Gemini
 
-To initiate a new release, follow these steps, and Gemini can assist you:
+To initiate a new release, instruct Gemini to start the process (e.g., "リリースを開始して"). Gemini will then guide you through the following steps:
 
-1.  **Update Version in `buildspec.json`**:
+1.  **Specify New Version**:
+    *   Gemini will display the current version.
     *   You will be prompted to provide the new version number (e.g., `1.0.0`, `1.0.0-beta1`).
-    *   Gemini will then update the `version` field in `buildspec.json` with this new version.
-2.  **Create a Pull Request (PR)**:
-    *   After updating `buildspec.json`, you should create a new branch, commit the change, and open a Pull Request for review.
-    *   **Important**: The release process will pause here, awaiting the merge of this PR.
-3.  **Push Git Tag (After PR Merge)**:
-    *   Once your PR (containing the `buildspec.json` version update) is merged into the main branch (e.g., `master` or `main`), you can then instruct Gemini to push the corresponding Git tag.
-    *   **Tag Format Constraint**: The tag must be in the format `X.Y.Z` (e.g., `1.2.3`), without a 'v' prefix.
-    *   Pushing the tag will trigger the automated release workflow in GitHub Actions.
-4.  **Monitor Release Progress**:
-    *   Gemini will provide updates on the release workflow's progress after the tag is pushed.
+    *   **Constraint**: The version must follow Semantic Versioning (e.g., `MAJOR.MINOR.PATCH`).
+
+2.  **Prepare & Update `buildspec.json`**:
+    *   Gemini will confirm the current branch is `main` and synchronized with the remote.
+    *   A new branch (`bump-X.Y.Z`) will be created.
+    *   The `version` field in `buildspec.json` will be updated.
+
+3.  **Create & Merge Pull Request (PR)**:
+    *   Gemini will create a PR for the version update.
+    *   You will be instructed to merge this PR.
+    *   **Pause**: The process pauses until you confirm the PR merge to Gemini.
+
+4.  **Push Git Tag**:
+    *   After PR merge confirmation, instruct Gemini to push the Git tag.
+    *   **Constraint**: The tag must be `X.Y.Z` (no 'v' prefix).
+    *   Pushing the tag triggers the automated release workflow.
+
+5.  **Finalize Release**:
+    *   Gemini will provide the draft release URL.
+    *   You should then complete the release on GitHub.
 
 **Example Interaction:**
 
-User: `リリースを開始して` (Start the release)
-Gemini: `はい、新しいリリースを開始します。まず、buildspec.json に記載するリリースバージョンを指定してください (例: 1.0.0, 1.0.0-beta1)。` (Okay, I will start a new release. First, please specify the release version to be written in buildspec.json (e.g., 1.0.0, 1.0.0-beta1).)
+User: `リリースを開始して`
+Gemini: `はい、新しいリリースを開始します。現在のバージョンは X.Y.Z です。buildspec.json に記載するリリースバージョンを指定してください (例: 1.0.0, 1.0.0-beta1)。`
 User: `1.2.3`
-Gemini: `buildspec.json のバージョンを 1.2.3 に更新します。よろしいですか？` (I will update the version in buildspec.json to 1.2.3. Is that okay?)
-User: `はい` (Yes)
-Gemini: `buildspec.json を更新しました。この変更を含むPRを作成し、マージしてください。PRがマージされたら、私にタグをプッシュするように指示してください。` (Updated buildspec.json. Please create a PR with this change and merge it. Once the PR is merged, instruct me to push the tag.)
-User: `タグをプッシュして` (Push the tag)
-Gemini: `バージョン 1.2.3 の Git タグをプッシュします。よろしいですか？` (I will push Git tag for version 1.2.3. Is that okay?)
-User: `はい` (Yes)
-Gemini: `Git タグ '1.2.3' をプッシュしました。GitHub Actions でリリースワークフローが開始されます。進捗を監視します。` (Pushed Git tag '1.2.3'. The release workflow will start in GitHub Actions. I will monitor the progress.)
-Gemini: `GitHub リリースドラフトのURL: https://github.com/kaito-tokyo/obs-showdraw/releases/tag/1.2.3` (GitHub Release Draft URL: https://github.com/kaito-tokyo/obs-showdraw/releases/tag/1.2.3)
+Gemini: `buildspec.json のバージョンを 1.2.3 に更新します。よろしいですか？`
+User: `はい`
+Gemini: `mainブランチにいることを確認します。`
+Gemini: `ブランチ 'bump-1.2.3' を作成します。`
+Gemini: `buildspec.json を更新しました。プルリクエストを作成します。`
+Gemini: `プルリクエストのURL: https://github.com/kaito-tokyo/obs-showdraw/pull/123`
+Gemini: `このプルリクエストをマージし、完了したら私に報告してください。`
+User: `マージしました`
+User: `タグをプッシュして`
+Gemini: `バージョン 1.2.3 の Git タグをプッシュします。よろしいですか？`
+User: `はい`
+Gemini: `Git タグ '1.2.3' をプッシュしました。GitHub Actions でリリースワークフローが開始されます。`
+Gemini: `GitHub リリースドラフトのURL: https://github.com/kaito-tokyo/obs-showdraw/releases/tag/1.2.3`
+Gemini: `GitHub上でリリースを完了してください。`


### PR DESCRIPTION
This pull request updates the `GEMINI.md` documentation to clarify and improve the instructions for release automation with Gemini. The changes make the release process more explicit, detailing each step and providing a clearer example interaction. It also specifies the default branch for the project.

Documentation improvements:

* Added a note specifying that the default branch of the project is `main`.
* Rewrote the release automation instructions to clarify the workflow, including explicit steps for version specification, branch preparation, PR creation/merge, tag pushing, and release finalization. The new instructions also clarify constraints and automation handled by Gemini.
* Enhanced the example interaction to reflect the updated workflow, showing step-by-step guidance from Gemini and the expected user actions.