### PR TITLE
Bump version to 1.0.6

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
     },
     "name": "obs-showdraw",
     "displayName": "Emphasize drawing on OBS",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "author": "Kaito Udagawa",
     "website": "https://github.com/kaito-tokyo/obs-showdraw",
     "email": "umireon@kaito.tokyo"


### PR DESCRIPTION
This pull request makes a minor update to the `buildspec.json` file, bumping the version number from 1.0.5 to 1.0.6.