### PR TITLE
Add Japanese locale and update English locale

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -35,7 +35,6 @@ morphologyClosingDilationKernelSize="Morphology Closing Dilation Kernel Size"
 
 scalingFactor="Scaling Factor [dB]"
 
-presetWindowCurrent="(Current)"
 presetWindowStrongDefault="(Strong Default)"
 presetWindowApply="Apply"
 presetWindowAddNewPrefix="New Preset"

--- a/data/locale/ja-JP.ini
+++ b/data/locale/ja-JP.ini
@@ -1,0 +1,60 @@
+pluginName="Show Draw"
+
+openPresetWindow="プリセットウィンドウを開く"
+
+updateCheckerPluginIsLatest="最新バージョンを使用しています。"
+updateCheckerUpdateAvailable="新しいバージョンが利用可能です。"
+
+extractionMode="抽出モード"
+extractionModeDefault="デフォルト"
+extractionModePassthrough="パススルー"
+extractionModeLuminanceExtraction="輝度抽出"
+extractionModeEdgeDetection="エッジ検出"
+extractionModeScaling="スケーリング"
+
+medianFilteringGroup="メディアンフィルタリング"
+medianFilteringKernelSize="メディアンフィルタリングカーネルサイズ"
+medianFilteringKernelSize1="フィルタリングなし"
+medianFilteringKernelSize3="3x3 (9ピクセル)"
+medianFilteringKernelSize5="5x5 (25ピクセル)"
+medianFilteringKernelSize7="7x7 (49ピクセル)"
+medianFilteringKernelSize9="9x9 (81ピクセル)"
+
+motionMapKernelSize="モーションマップカーネルサイズ"
+motionMapKernelSize1="1x1 (1ピクセル)"
+motionMapKernelSize3="3x3 (9ピクセル)"
+motionMapKernelSize5="5x5 (25ピクセル)"
+motionMapKernelSize7="7x7 (49ピクセル)"
+motionMapKernelSize9="9x9 (81ピクセル)"
+
+motionAdaptiveFilteringStrength="動き適応型フィルタリング強度"
+motionAdaptiveFilteringMotionThreshold="動き適応型フィルタリングモーションしきい値"
+
+morphologyOpeningErosionKernelSize="モルフォロジーオープニング収縮カーネルサイズ"
+morphologyOpeningDilationKernelSize="モルフォロジーオープニング膨張カーネルサイズ"
+
+morphologyClosingErosionKernelSize="モルフォロジークロージング収縮カーネルサイズ"
+morphologyClosingDilationKernelSize="モルフォロジークロージング膨張カーネルサイズ"
+
+scalingFactor="スケーリングファクター [dB]"
+
+presetWindowStrongDefault="(強いデフォルト)"
+presetWindowApply="適用"
+presetWindowAddNewPrefix="新しいプリセット"
+presetWindowAddTitle="新しいプリセットを追加"
+presetWindowAddLabel="新しいプリセットの名前を入力してください:"
+presetWindowRemoveTitle="プリセットを削除"
+presetWindowRemoveLabel="このプリセットを削除してもよろしいですか？"
+presetWindowInvalidJson="無効なJSON形式です。"
+presetWindowJsonOk="有効なJSON形式です。"
+
+configHelperInvalidExtractionMode="無効な抽出モードです。"
+configHelperInvalidMedianFilteringKernelSize="無効なメディアンフィルタリングカーネルサイズです。"
+configHelperInvalidMotionMapKernelSize="無効なモーションマップカーネルサイズです。"
+configHelperInvalidMotionAdaptiveFilteringStrength="無効な動き適応型フィルタリング強度です。"
+configHelperInvalidMotionAdaptiveFilteringMotionThreshold="無効な動き適応型フィルタリングモーションしきい値です。"
+configHelperInvalidMorphologyOpeningErosionKernelSize="無効なモルフォロジーオープニング収縮カーネルサイズです。"
+configHelperInvalidMorphologyOpeningDilationKernelSize="無効なモルフォロジーオープニング膨張カーネルサイズです。"
+configHelperInvalidMorphologyClosingErosionKernelSize="無効なモルフォロジークロージング収縮カーネルサイズです。"
+configHelperInvalidMorphologyClosingDilationKernelSize="無効なモルフォロジークロージング膨張カーネルサイズです。"
+configHelperInvalidScalingFactor="無効なスケーリングファクターです。"


### PR DESCRIPTION
This pull request primarily adds comprehensive Japanese translations for new and existing UI elements and configuration options, and makes a minor cleanup to the English locale file. The most significant changes are the addition of new translation keys and values for the Japanese locale, covering plugin names, extraction modes, filtering options, morphology parameters, scaling, preset management, and configuration helper error messages.

**Japanese locale additions and improvements:**

* Added Japanese translations for plugin names, extraction modes, median filtering options, motion map settings, morphology operations, scaling factor, and preset window UI elements in `data/locale/ja-JP.ini`.
* Included Japanese error messages for invalid configuration values in `data/locale/ja-JP.ini`.

**English locale cleanup:**

* Removed the unused `presetWindowCurrent` key from `data/locale/en-US.ini`.Added a new Japanese translation file (ja-JP.ini) for UI strings. Removed the unused 'presetWindowCurrent' entry from the English locale file (en-US.ini).