### PR TITLE
Refactor variable naming to camelCase style

### DIFF
--- a/src/DrawingEffect.cpp
+++ b/src/DrawingEffect.cpp
@@ -72,35 +72,35 @@ DrawingEffect::DrawingEffect()
 	}
 
 	try {
-		texture_image = getEffectParam(effect, "image");
-		texture_image1 = getEffectParam(effect, "image1");
+		textureImage = getEffectParam(effect, "image");
+		textureImage1 = getEffectParam(effect, "image1");
 
-		float_texel_width = getEffectParam(effect, "texelWidth");
-		float_texel_height = getEffectParam(effect, "texelHeight");
-		int_kernel_size = getEffectParam(effect, "kernelSize");
+		floatTexelWidth = getEffectParam(effect, "texelWidth");
+		floatTexelHeight = getEffectParam(effect, "texelHeight");
+		intKernelSize = getEffectParam(effect, "kernelSize");
 
-		texture_motion_map = getEffectParam(effect, "motionMap");
-		float_strength = getEffectParam(effect, "strength");
-		float_motion_threshold = getEffectParam(effect, "motionThreshold");
+		textureMotionMap = getEffectParam(effect, "motionMap");
+		floatStrength = getEffectParam(effect, "strength");
+		floatMotionThreshold = getEffectParam(effect, "motionThreshold");
 
-		float_high_threshold = getEffectParam(effect, "highThreshold");
-		float_low_threshold = getEffectParam(effect, "lowThreshold");
+		floatHighThreshold = getEffectParam(effect, "highThreshold");
+		floatLowThreshold = getEffectParam(effect, "lowThreshold");
 
-		float_scaling_factor = getEffectParam(effect, "scalingFactor");
+		floatScalingFactor = getEffectParam(effect, "scalingFactor");
 
-		tech_draw = getEffectTech(effect, "Draw");
-		tech_extract_luminance = getEffectTech(effect, "ExtractLuminance");
-		tech_median_filtering = getEffectTech(effect, "MedianFiltering");
-		tech_calculate_motion_map = getEffectTech(effect, "CalculateMotionMap");
-		tech_motion_adaptive_filtering = getEffectTech(effect, "MotionAdaptiveFiltering");
-		tech_apply_sobel = getEffectTech(effect, "ApplySobel");
-		tech_suppress_non_maximum = getEffectTech(effect, "SuppressNonMaximum");
-		tech_hysteresis_classify = getEffectTech(effect, "HysteresisClassify");
-		tech_hysteresis_propagate = getEffectTech(effect, "HysteresisPropagate");
-		tech_hysteresis_finalize = getEffectTech(effect, "HysteresisFinalize");
-		tech_erosion = getEffectTech(effect, "Erosion");
-		tech_dilation = getEffectTech(effect, "Dilation");
-		tech_scaling = getEffectTech(effect, "Scaling");
+		techDraw = getEffectTech(effect, "Draw");
+		techExtractLuminance = getEffectTech(effect, "ExtractLuminance");
+		techMedianFiltering = getEffectTech(effect, "MedianFiltering");
+		techCalculateMotionMap = getEffectTech(effect, "CalculateMotionMap");
+		techMotionAdaptiveFiltering = getEffectTech(effect, "MotionAdaptiveFiltering");
+		techApplySobel = getEffectTech(effect, "ApplySobel");
+		techSuppressNonMaximum = getEffectTech(effect, "SuppressNonMaximum");
+		techHysteresisClassify = getEffectTech(effect, "HysteresisClassify");
+		techHysteresisPropagate = getEffectTech(effect, "HysteresisPropagate");
+		techHysteresisFinalize = getEffectTech(effect, "HysteresisFinalize");
+		techErosion = getEffectTech(effect, "Erosion");
+		techDilation = getEffectTech(effect, "Dilation");
+		techScaling = getEffectTech(effect, "Scaling");
 	} catch (const std::exception &e) {
 		gs_effect_destroy(effect);
 		effect = nullptr;

--- a/src/DrawingEffect.hpp
+++ b/src/DrawingEffect.hpp
@@ -30,35 +30,35 @@ public:
 
 	gs_effect_t *effect = nullptr;
 
-	gs_eparam_t *texture_image = nullptr;
-	gs_eparam_t *texture_image1 = nullptr;
+	gs_eparam_t *textureImage = nullptr;
+	gs_eparam_t *textureImage1 = nullptr;
 
-	gs_eparam_t *float_texel_width = nullptr;
-	gs_eparam_t *float_texel_height = nullptr;
-	gs_eparam_t *int_kernel_size = nullptr;
+	gs_eparam_t *floatTexelWidth = nullptr;
+	gs_eparam_t *floatTexelHeight = nullptr;
+	gs_eparam_t *intKernelSize = nullptr;
 
-	gs_eparam_t *texture_motion_map = nullptr;
-	gs_eparam_t *float_strength = nullptr;
-	gs_eparam_t *float_motion_threshold = nullptr;
+	gs_eparam_t *textureMotionMap = nullptr;
+	gs_eparam_t *floatStrength = nullptr;
+	gs_eparam_t *floatMotionThreshold = nullptr;
 
-	gs_eparam_t *float_high_threshold = nullptr;
-	gs_eparam_t *float_low_threshold = nullptr;
+	gs_eparam_t *floatHighThreshold = nullptr;
+	gs_eparam_t *floatLowThreshold = nullptr;
 
-	gs_eparam_t *float_scaling_factor = nullptr;
+	gs_eparam_t *floatScalingFactor = nullptr;
 
-	gs_technique_t *tech_draw = nullptr;
-	gs_technique_t *tech_extract_luminance = nullptr;
-	gs_technique_t *tech_median_filtering = nullptr;
-	gs_technique_t *tech_calculate_motion_map = nullptr;
-	gs_technique_t *tech_motion_adaptive_filtering = nullptr;
-	gs_technique_t *tech_apply_sobel = nullptr;
-	gs_technique_t *tech_suppress_non_maximum = nullptr;
-	gs_technique_t *tech_hysteresis_classify = nullptr;
-	gs_technique_t *tech_hysteresis_propagate = nullptr;
-	gs_technique_t *tech_hysteresis_finalize = nullptr;
-	gs_technique_t *tech_erosion = nullptr;
-	gs_technique_t *tech_dilation = nullptr;
-	gs_technique_t *tech_scaling = nullptr;
+	gs_technique_t *techDraw = nullptr;
+	gs_technique_t *techExtractLuminance = nullptr;
+	gs_technique_t *techMedianFiltering = nullptr;
+	gs_technique_t *techCalculateMotionMap = nullptr;
+	gs_technique_t *techMotionAdaptiveFiltering = nullptr;
+	gs_technique_t *techApplySobel = nullptr;
+	gs_technique_t *techSuppressNonMaximum = nullptr;
+	gs_technique_t *techHysteresisClassify = nullptr;
+	gs_technique_t *techHysteresisPropagate = nullptr;
+	gs_technique_t *techHysteresisFinalize = nullptr;
+	gs_technique_t *techErosion = nullptr;
+	gs_technique_t *techDilation = nullptr;
+	gs_technique_t *techScaling = nullptr;
 };
 
 } // namespace obs_showdraw

--- a/src/ShowDrawFilterContext.h
+++ b/src/ShowDrawFilterContext.h
@@ -89,10 +89,10 @@ private:
 
 	double scaling_factor;
 
-	gs_texture_t *texture_source;
-	gs_texture_t *texture_target;
-	gs_texture_t *texture_motion_map;
-	gs_texture_t *texture_previous_luminance;
+	gs_texture_t *textureSource;
+	gs_texture_t *textureTarget;
+	gs_texture_t *textureMotionMap;
+	gs_texture_t *texturePreviousLuminance;
 
 	std::shared_future<std::optional<LatestVersion>> futureLatestVersion;
 };


### PR DESCRIPTION
Renamed variables and member fields in DrawingEffect and ShowDrawFilterContext from snake_case to camelCase for consistency with coding standards. This affects both effect/technique parameters and texture variables across implementation and header files.