### PR TITLE
Handle release event payload in metadata endpoints

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -54,6 +54,10 @@ jobs:
             --site "${{ steps.pages.outputs.origin }}" \
             --base "${{ steps.pages.outputs.base_path }}"
         working-directory: "${{ env.BUILD_PATH }}"
+        env:
+          EVENT_NAME: "${{ github.event_name }}"
+          EVENT_PAYLOAD: "${{ toJson(github.event) }}"
+
 
       - name: "Upload artifact"
         uses: "actions/upload-pages-artifact@v4"

--- a/docs/src/pages/metadata/latest-release.json.ts
+++ b/docs/src/pages/metadata/latest-release.json.ts
@@ -1,4 +1,17 @@
 export async function GET() {
+  const eventName = process.env["EVENT_NAME"] ?? "";
+  const eventPayload = JSON.parse(process.env["EVENT_PAYLOAD"] ?? "{}");
+
+  if (eventName === "release" && eventPayload.action === "published") {
+    return new Response(JSON.stringify(eventPayload.release, null, 2), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  // Fallback: Fetch the latest release from GitHub API
   const response = await fetch(
     "https://api.github.com/repos/kaito-tokyo/obs-showdraw/releases/latest",
   );

--- a/docs/src/pages/metadata/latest-version.txt.ts
+++ b/docs/src/pages/metadata/latest-version.txt.ts
@@ -1,4 +1,18 @@
 export async function GET() {
+  const eventName = process.env["EVENT_NAME"] ?? "";
+  const eventPayload = JSON.parse(process.env["EVENT_PAYLOAD"] ?? "{}");
+
+  if (eventName === "release" && eventPayload.action === "published") {
+    const tagName = eventPayload.release.tag_name;
+    return new Response(tagName, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/plain",
+      },
+    });
+  }
+
+  // Fallback: Fetch the latest release from GitHub API
   const response = await fetch(
     "https://api.github.com/repos/kaito-tokyo/obs-showdraw/releases/latest",
   );


### PR DESCRIPTION
This pull request updates the workflow and server-side logic to improve how release metadata is handled during GitHub Actions runs. The main change is that release information is now passed directly from the workflow to the server code when a release event occurs, allowing the endpoints to serve up-to-date release data without always querying the GitHub API.

**Workflow and environment variable updates:**

* [`.github/workflows/astro.yml`](diffhunk://#diff-927097e89600a183e73044f6cb663c2c9c8f5aa616e1f2d734fcbc1b009449cdR57-R60): The workflow now sets `EVENT_NAME` and `EVENT_PAYLOAD` environment variables, containing the event type and payload, for subsequent steps.

**Server-side release metadata handling:**

* [`docs/src/pages/metadata/latest-release.json.ts`](diffhunk://#diff-da745041ece009fe6e7d92db41e96574232c47b533fee7a9554a89586f6afbfcR2-R14): The endpoint checks if the workflow event is a published release and, if so, directly returns the release payload from the environment variable. Otherwise, it falls back to fetching the latest release from the GitHub API.
* [`docs/src/pages/metadata/latest-version.txt.ts`](diffhunk://#diff-ca0336e28258f34c55a6c0c3a7a7160b1521976436fe72e7fcc5a5e641b20031R2-R15): Similarly, this endpoint now returns the tag name from the release event payload if available, or fetches it from the GitHub API as a fallback.Update latest-release.json.ts and latest-version.txt.ts to return release data directly from the GitHub Actions event payload when triggered by a published release event. Also update the workflow to pass event context as environment variables to the build, improving release metadata accuracy and reducing unnecessary API calls.