### PR TITLE
Sharertest 3

### DIFF
--- a/tests/DrawingEffect_shader_test.cpp
+++ b/tests/DrawingEffect_shader_test.cpp
@@ -17,6 +17,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 */
 
 #include <iostream>
+#include <memory>
 #include <thread>
 
 #include <obs-module.h>
@@ -33,29 +34,39 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 using namespace kaito_tokyo::obs_bridge_utils;
 using namespace kaito_tokyo::obs_showdraw;
 
-TEST(DrawingEffectShaderTest, Draw)
-{
-	cv::Scalar redColor(0, 0, 255, 255);
-	cv::Mat sourceImage(HEIGHT, WIDTH, CV_8UC4, redColor);
+class DrawingEffectShaderTest : public ::testing::Test {
+protected:
+	void SetUp() override
+	{
+		effect = make_unique_gs_effect_from_file(CMAKE_SOURCE_DIR "/data/effects/drawing.effect");
+		drawingEffect = std::make_unique<DrawingEffect>(std::move(effect));
+
+		const uint8_t *data = sourceImage.data;
+		sourceTexture = make_unique_gs_texture(WIDTH, HEIGHT, GS_BGRA, 1, &data, 0);
+
+		targetBufferedTexture = std::make_unique<kaito_tokyo::obs_showdraw::BufferedTexture>(WIDTH, HEIGHT);
+	}
 
 	graphics_context_guard guard;
-	auto effect = make_unique_gs_effect_from_file(CMAKE_SOURCE_DIR "/data/effects/drawing.effect");
 
-	DrawingEffect drawingEffect(std::move(effect));
+	cv::Mat sourceImage = cv::Mat(HEIGHT, WIDTH, CV_8UC4, cv::Scalar(0, 0, 255, 255));
 
-	const uint8_t *data = sourceImage.data;
-	auto sourceTexture = make_unique_gs_texture(WIDTH, HEIGHT, GS_BGRA, 1, &data, 0);
+	unique_gs_effect_t effect;
+	std::unique_ptr<DrawingEffect> drawingEffect;
+	unique_gs_texture_t sourceTexture;
+	std::unique_ptr<kaito_tokyo::obs_showdraw::BufferedTexture> targetBufferedTexture;
+};
 
-	kaito_tokyo::obs_showdraw::BufferedTexture targetBufferedTexture(WIDTH, HEIGHT);
+TEST_F(DrawingEffectShaderTest, Draw)
+{
+	drawingEffect->drawFinalImage(targetBufferedTexture->getTexture(), sourceTexture.get());
 
-	drawingEffect.drawFinalImage(targetBufferedTexture.getTexture(), sourceTexture.get());
+	targetBufferedTexture->stage();
+	ASSERT_TRUE(targetBufferedTexture->sync());
+	ASSERT_TRUE(targetBufferedTexture->sync());
 
-	targetBufferedTexture.stage();
-	ASSERT_TRUE(targetBufferedTexture.sync());
-	ASSERT_TRUE(targetBufferedTexture.sync());
-
-	cv::Mat targetImage(HEIGHT, WIDTH, CV_8UC4, (void *)targetBufferedTexture.getBuffer().data(),
-			    targetBufferedTexture.bufferLinesize);
+	cv::Mat targetImage(HEIGHT, WIDTH, CV_8UC4, (void *)targetBufferedTexture->getBuffer().data(),
+			    targetBufferedTexture->bufferLinesize);
 
 	cv::Mat diff;
 	cv::absdiff(sourceImage, targetImage, diff);
@@ -64,5 +75,32 @@ TEST(DrawingEffectShaderTest, Draw)
 	EXPECT_EQ(sum[0], 0) << "B channel differs";
 	EXPECT_EQ(sum[1], 0) << "G channel differs";
 	EXPECT_EQ(sum[2], 0) << "R channel differs";
+	EXPECT_EQ(sum[3], 0) << "A channel differs";
+}
+
+TEST_F(DrawingEffectShaderTest, ExtractLuminance)
+{
+	drawingEffect->applyLuminanceExtractionPass(targetBufferedTexture->getTexture(), sourceTexture.get());
+
+	targetBufferedTexture->stage();
+	ASSERT_TRUE(targetBufferedTexture->sync());
+	ASSERT_TRUE(targetBufferedTexture->sync());
+
+	cv::Mat targetImage(HEIGHT, WIDTH, CV_8UC4, (void *)targetBufferedTexture->getBuffer().data(),
+			    targetBufferedTexture->bufferLinesize);
+
+	// The luminance value for red (255, 0, 0) is calculated as:
+	// luma = 0.299 * R + 0.587 * G + 0.114 * B
+	// luma = 0.299 * 255 + 0.587 * 0 + 0.114 * 0 = 76.245
+	// The shader returns (luma, luma, luma, 1.0), which corresponds to (76, 76, 76, 255) in 8-bit BGRA.
+	cv::Mat expectedImage(HEIGHT, WIDTH, CV_8UC4, cv::Scalar(76, 76, 76, 255));
+
+	cv::Mat diff;
+	cv::absdiff(expectedImage, targetImage, diff);
+	cv::Scalar sum = cv::sum(diff);
+
+	EXPECT_LE(sum[0], 255) << "B channel differs";
+	EXPECT_LE(sum[1], 255) << "G channel differs";
+	EXPECT_LE(sum[2], 255) << "R channel differs";
 	EXPECT_EQ(sum[3], 0) << "A channel differs";
 }

--- a/tests/DrawingEffect_shader_test.cpp
+++ b/tests/DrawingEffect_shader_test.cpp
@@ -38,6 +38,8 @@ class DrawingEffectShaderTest : public ::testing::Test {
 protected:
 	void SetUp() override
 	{
+		graphics_context_guard guard;
+
 		effect = make_unique_gs_effect_from_file(CMAKE_SOURCE_DIR "/data/effects/drawing.effect");
 		drawingEffect = std::make_unique<DrawingEffect>(std::move(effect));
 
@@ -46,8 +48,6 @@ protected:
 
 		targetBufferedTexture = std::make_unique<kaito_tokyo::obs_showdraw::BufferedTexture>(WIDTH, HEIGHT);
 	}
-
-	graphics_context_guard guard;
 
 	cv::Mat sourceImage = cv::Mat(HEIGHT, WIDTH, CV_8UC4, cv::Scalar(0, 0, 255, 255));
 
@@ -59,6 +59,8 @@ protected:
 
 TEST_F(DrawingEffectShaderTest, Draw)
 {
+	graphics_context_guard guard;
+
 	drawingEffect->drawFinalImage(targetBufferedTexture->getTexture(), sourceTexture.get());
 
 	targetBufferedTexture->stage();
@@ -80,6 +82,8 @@ TEST_F(DrawingEffectShaderTest, Draw)
 
 TEST_F(DrawingEffectShaderTest, ExtractLuminance)
 {
+	graphics_context_guard guard;
+
 	drawingEffect->applyLuminanceExtractionPass(targetBufferedTexture->getTexture(), sourceTexture.get());
 
 	targetBufferedTexture->stage();


### PR DESCRIPTION
This pull request refactors the `DrawingEffect_shader_test.cpp` test suite to improve code organization and adds a new test for the luminance extraction shader pass. The changes focus on making the tests more maintainable and expanding test coverage for the `DrawingEffect` class.

**Test refactoring and structure improvements:**

* Refactored the existing test into a proper test fixture by introducing the `DrawingEffectShaderTest` class, moving shared setup code into `SetUp()`, and updating member variables to use smart pointers for better memory management. (`tests/DrawingEffect_shader_test.cpp`, [tests/DrawingEffect_shader_test.cppL36-R71](diffhunk://#diff-e53c8f6a5871d28073acc01c75265cfd160214254128df29a0e32272f1f7a412L36-R71))
* Added `#include <memory>` to support the use of smart pointers. (`tests/DrawingEffect_shader_test.cpp`, [tests/DrawingEffect_shader_test.cppR20](diffhunk://#diff-e53c8f6a5871d28073acc01c75265cfd160214254128df29a0e32272f1f7a412R20))

**Test coverage enhancements:**

* Added a new test case `ExtractLuminance` to verify the output of the `applyLuminanceExtractionPass` method, ensuring the shader correctly extracts luminance from a red source image. (`tests/DrawingEffect_shader_test.cpp`, [tests/DrawingEffect_shader_test.cppR82-R110](diffhunk://#diff-e53c8f6a5871d28073acc01c75265cfd160214254128df29a0e32272f1f7a412R82-R110))