### PR TITLE
Shadertest 8

### DIFF
--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -137,7 +137,7 @@ jobs:
         run: "ctest --preset windows-testing-ci-x64 --verbose"
 
       - name: "Run shader tests"
-        run: "${{ github.workspace }}/scripts/run-gtest-with-retry.bash ${{ github.workspace }}/build_x64/tests/RelWithDebInfo/DrawingEffect_shader_test 100"
+        run: "${{ github.workspace }}/scripts/run-gtest-with-retry.bash --verbose ${{ github.workspace }}/build_x64/tests/RelWithDebInfo/DrawingEffect_shader_test 100"
         working-directory: "${{ github.workspace }}/build_x64/tests/RelWithDebInfo/obs-studio/bin/64bit"
 
   RunTestsOnUbuntu:

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -137,8 +137,9 @@ jobs:
         run: "ctest --preset windows-testing-ci-x64 --verbose"
 
       - name: "Run shader tests"
-        run: "${{ github.workspace }}/scripts/run-gtest-with-retry.bash --verbose ${{ github.workspace }}/build_x64/tests/RelWithDebInfo/DrawingEffect_shader_test 100"
-        working-directory: "${{ github.workspace }}/build_x64/tests/RelWithDebInfo/obs-studio/bin/64bit"
+        run: "bash ${{ github.workspace }}\\scripts\\run-gtest-with-retry.bash --verbose ${{ github.workspace }}\\build_x64\\tests\\RelWithDebInfo\\DrawingEffect_shader_test 100"
+        working-directory: "${{ github.workspace }}\\build_x64\\tests\\RelWithDebInfo\\obs-studio\\bin\\64bit"
+        shell: "pwsh"
 
   RunTestsOnUbuntu:
     name: "Run Tests on Ubuntu"

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -83,6 +83,7 @@ jobs:
 
       - name: "Run shader tests"
         run: "./scripts/run-gtest-with-retry.bash ./build_macos/tests/RelWithDebInfo/DrawingEffect_shader_test 100"
+        working-directory: "${{ github.workspace }}/build_macos/tests/RelWithDebInfo/obs-studio/bin/64bit"
 
   RunTestsOnWindows:
     name: "Run Tests on Windows"
@@ -135,8 +136,9 @@ jobs:
       - name: "Run tests"
         run: "ctest --preset windows-testing-ci-x64 --verbose"
 
-      # - name: "Run shader tests"
-      #   run: "./scripts/run-gtest-with-retry.bash ./build_x64/tests/RelWithDebInfo/DrawingEffect_shader_test 100"
+      - name: "Run shader tests"
+        run: "${{ github.workspace }}/scripts/run-gtest-with-retry.bash ${{ github.workspace }}/build_x64/tests/RelWithDebInfo/DrawingEffect_shader_test 100"
+        working-directory: "${{ github.workspace }}/build_x64/tests/RelWithDebInfo/obs-studio/bin/64bit"
 
   RunTestsOnUbuntu:
     name: "Run Tests on Ubuntu"
@@ -225,4 +227,5 @@ jobs:
 
       - name: "Run shader tests"
         run: "./scripts/run-gtest-with-retry.bash ./build_x86_64/tests/DrawingEffect_shader_test 100"
+        working-directory: "${{ github.workspace }}/build_x86_64/tests/RelWithDebInfo/obs-studio/bin/64bit"
 

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -82,7 +82,7 @@ jobs:
         run: "ctest --preset macos-testing-ci --verbose"
 
       - name: "Run shader tests"
-        run: "./scripts/run-gtest-with-retry.bash ./build_macos/tests/RelWithDebInfo/DrawingEffect_shader_test 100"
+        run: "${{ github.workspace }}/scripts/run-gtest-with-retry.bash ${{ github.workspace }}/build_macos/tests/RelWithDebInfo/DrawingEffect_shader_test 100"
         working-directory: "${{ github.workspace }}/build_macos/tests/RelWithDebInfo/obs-studio/bin/64bit"
 
   RunTestsOnWindows:
@@ -226,6 +226,6 @@ jobs:
         run: "ctest --preset ubuntu-testing-ci-x86_64 --verbose"
 
       - name: "Run shader tests"
-        run: "./scripts/run-gtest-with-retry.bash ./build_x86_64/tests/DrawingEffect_shader_test 100"
+        run: "${{ github.workspace }}/scripts/run-gtest-with-retry.bash ${{ github.workspace }}/build_x86_64/tests/DrawingEffect_shader_test 100"
         working-directory: "${{ github.workspace }}/build_x86_64/tests/RelWithDebInfo/obs-studio/bin/64bit"
 

--- a/.github/workflows/push-testing.yaml
+++ b/.github/workflows/push-testing.yaml
@@ -83,7 +83,7 @@ jobs:
 
       - name: "Run shader tests"
         run: "${{ github.workspace }}/scripts/run-gtest-with-retry.bash ${{ github.workspace }}/build_macos/tests/RelWithDebInfo/DrawingEffect_shader_test 100"
-        working-directory: "${{ github.workspace }}/build_macos/tests/RelWithDebInfo/obs-studio/bin/64bit"
+        working-directory: "${{ github.workspace }}/build_macos/tests/obs-studio/bin/64bit"
 
   RunTestsOnWindows:
     name: "Run Tests on Windows"
@@ -138,7 +138,7 @@ jobs:
 
       - name: "Run shader tests"
         run: "bash ${{ github.workspace }}\\scripts\\run-gtest-with-retry.bash --verbose ${{ github.workspace }}\\build_x64\\tests\\RelWithDebInfo\\DrawingEffect_shader_test 100"
-        working-directory: "${{ github.workspace }}\\build_x64\\tests\\RelWithDebInfo\\obs-studio\\bin\\64bit"
+        working-directory: "${{ github.workspace }}\\build_x64\\tests\\obs-studio\\bin\\64bit"
         shell: "pwsh"
 
   RunTestsOnUbuntu:
@@ -228,5 +228,5 @@ jobs:
 
       - name: "Run shader tests"
         run: "${{ github.workspace }}/scripts/run-gtest-with-retry.bash ${{ github.workspace }}/build_x86_64/tests/DrawingEffect_shader_test 100"
-        working-directory: "${{ github.workspace }}/build_x86_64/tests/RelWithDebInfo/obs-studio/bin/64bit"
+        working-directory: "${{ github.workspace }}/build_x86_64/tests/obs-studio/bin/64bit"
 


### PR DESCRIPTION
This pull request improves the shader test execution process across all platforms by updating the GitHub Actions workflow and enhancing the `run-gtest-with-retry.bash` script. The main focus is on adding support for a verbose mode, improving test output clarity, and ensuring tests are run from the correct working directories.

**Workflow improvements:**

* Added `working-directory` to shader test steps in the GitHub Actions workflow for macOS, Windows, and Ubuntu, ensuring tests are executed from the correct binary location. [[1]](diffhunk://#diff-fa430cdb29b022935d4f20907b557bb784d0947123f6ea5afce289ab185f255bR86) [[2]](diffhunk://#diff-fa430cdb29b022935d4f20907b557bb784d0947123f6ea5afce289ab185f255bL138-R141) [[3]](diffhunk://#diff-fa430cdb29b022935d4f20907b557bb784d0947123f6ea5afce289ab185f255bR230)
* Re-enabled and improved the shader test step on Windows, now using the updated script and correct working directory.

**Script enhancements (`scripts/run-gtest-with-retry.bash`):**

* Added support for a `--verbose` flag to show output for all test attempts; without it, only failed attempts' output is shown. Updated argument parsing and usage documentation accordingly. [[1]](diffhunk://#diff-bd30cb872366cb61a2c4a10b85bfc14bf972c7d6dec598528668a3d10b8fb9afL8-R44) [[2]](diffhunk://#diff-bd30cb872366cb61a2c4a10b85bfc14bf972c7d6dec598528668a3d10b8fb9afR60-L50)
* Improved output handling: always shows output on failure, and conditionally on success if verbose mode is enabled; removed the previous `HIDE_SUCCESS_OUTPUT` logic for clarity.