### PR TITLE
Shadertest 10

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,6 +15,11 @@
 2. Run `cmake --build --preset macos-testing`.
 3. Run `ctest --preset macos-testing --rerun-failed --output-on-failure`.
 
+## How to test the effect shader (DrawingEffect_shader) on macOS
+1. Run `cmake --preset macos-testing`.
+2. Run `cmake --build --preset macos-testing`.
+3. Run `( cd build_macos/tests/obs-studio/bin/64bit && ../../../../../scripts/run-gtest-with-retry.bash --verbose ../../../RelWithDebInfo/DrawingEffect_shader_test )`
+
 ## How to test plugin with OBS
 
 1. Run `cmake --preset macos-testing` only when CMake-related changes are made.

--- a/data/effects/drawing.effect
+++ b/data/effects/drawing.effect
@@ -67,7 +67,7 @@ float4 PSDraw(VertInOut vert_in) : TARGET
 float4 PSExtractLuminance(VertInOut vert_in) : TARGET
 {
 	float4 color = image.Sample(def_sampler, vert_in.uv);
-	float luma = saturate(dot(color.rgb, float3(0.299, 0.587, 0.114)));
+	float luma = saturate(dot(color.rgb, float3(0.2126, 0.7152, 0.0722)));
 	return float4(luma, luma, luma, 1.0);
 }
 

--- a/scripts/run-gtest-with-retry.bash
+++ b/scripts/run-gtest-with-retry.bash
@@ -119,9 +119,13 @@ for test_case in $test_cases; do
             echo "    ^^^ End of output ^^^"
         fi
     done
-    
-    if ! $is_successful; then
+
+    # Add the test case to the appropriate list based on the final result
+    if $is_successful; then
+        succeeded_tests+=("$test_case")
+    else
         echo "[FAILED]: $test_case did not pass after $MAX_RETRIES attempts."
+        failed_tests+=("$test_case")
     fi
     echo "----------------------------------------"
 done

--- a/tests/DrawingEffect_shader_test.cpp
+++ b/tests/DrawingEffect_shader_test.cpp
@@ -97,3 +97,55 @@ TEST_F(DrawingEffectShaderTest, Draw)
 
 	gs_stagesurface_unmap(stagesurf.get());
 }
+
+TEST_F(DrawingEffectShaderTest, ExtractLuminance)
+{
+	graphics_context_guard guard;
+
+	int width = 1;
+	int height = 1;
+	gs_color_format colorFormat = GS_BGRX;
+
+	// Red color in BGRX format {B, G, R, A}
+	const std::vector<uint8_t> sourcePixels = {0, 0, 255, 255};
+	const uint8_t *sourceData = sourcePixels.data();
+	auto sourceTexture = make_unique_gs_texture(width, height, colorFormat, 1, &sourceData, 0);
+	auto targetTexture = make_unique_gs_texture(width, height, colorFormat, 1, nullptr, GS_RENDER_TARGET);
+
+	gs_viewport_push();
+	gs_projection_push();
+	gs_matrix_push();
+
+	gs_set_viewport(0, 0, width, height);
+	gs_ortho(0.0f, (float)width, 0.0f, (float)height, -100.0f, 100.0f);
+	gs_matrix_identity();
+
+	drawingEffect->applyLuminanceExtractionPass(targetTexture.get(), sourceTexture.get());
+	gs_flush();
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+	gs_matrix_pop();
+	gs_projection_pop();
+	gs_viewport_pop();
+
+	unique_gs_stagesurf_t stagesurf = make_unique_gs_stagesurf(width, height, colorFormat);
+	gs_stage_texture(stagesurf.get(), targetTexture.get());
+
+	uint8_t *data = nullptr;
+	uint32_t linesize = 0;
+	ASSERT_TRUE(gs_stagesurface_map(stagesurf.get(), &data, &linesize));
+
+	// The shader calculates luma = dot(color.rgb, float3(0.299, 0.587, 0.114)).
+	// Assuming the texture sampler correctly maps BGRX to RGB for the shader,
+	// the input color (0, 0, 255) becomes (1.0, 0.0, 0.0) in the shader.
+	// luma = 0.299 * 1.0 + 0.587 * 0.0 + 0.114 * 0.0 = 0.299.
+	// The output color is (luma, luma, luma, 1.0).
+	// In 8-bit format, this is 0.299 * 255 = 76.245, which is 76.
+	// The output pixel in BGRX should be (76, 76, 76, 255).
+	EXPECT_EQ(76, data[0]); // Blue
+	EXPECT_EQ(76, data[1]); // Green
+	EXPECT_EQ(76, data[2]); // Red
+	EXPECT_EQ(255, data[3]); // Alpha
+
+	gs_stagesurface_unmap(stagesurf.get());
+}


### PR DESCRIPTION
This pull request improves the luminance extraction shader, enhances test coverage for the effect shader, and updates the test infrastructure to better report results. The most important changes are grouped below:

### Shader and Algorithm Improvements

* Updated the luminance extraction formula in `drawing.effect` to use the more accurate Rec. 709 coefficients (`float3(0.2126, 0.7152, 0.0722)`) instead of the older Rec. 601 values.

### Testing Enhancements

* Added a new unit test (`ExtractLuminance`) in `DrawingEffect_shader_test.cpp` to verify the output of the luminance extraction pass, including detailed expectations for pixel values.
* Added step-by-step instructions to `GEMINI.md` on how to build and run the `DrawingEffect_shader` test on macOS.

### Test Infrastructure

* Improved the `run-gtest-with-retry.bash` script to track and report both succeeded and failed test cases after retries, making test outcomes clearer.