### PR TITLE
Median testing

### DIFF
--- a/data/effects/drawing-test.effect
+++ b/data/effects/drawing-test.effect
@@ -24,3 +24,18 @@ technique TestMedian9
 		pixel_shader = PSTestMedian9(vert_in);
 	}
 }
+
+float4 PSTestMedian3(VertInOut vert_in) : TARGET
+{
+	float value = median3(v0, v1, v2);
+	return float4(value, value, value, 1.0);
+}
+
+technique TestMedian3
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader = PSTestMedian3(vert_in);
+	}
+}

--- a/data/effects/drawing-test.effect
+++ b/data/effects/drawing-test.effect
@@ -1,1 +1,26 @@
 #include "drawing.effect"
+
+uniform float v0;
+uniform float v1;
+uniform float v2;
+uniform float v3;
+uniform float v4;
+uniform float v5;
+uniform float v6;
+uniform float v7;
+uniform float v8;
+
+float4 PSTestMedian9(VertInOut vert_in) : TARGET
+{
+	float value = median9(v0, v1, v2, v3, v4, v5, v6, v7, v8);
+	return float4(value, value, value, 1.0);
+}
+
+technique TestMedian9
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader = PSTestMedian9(vert_in);
+	}
+}

--- a/tests/DrawingEffect_shader_test.cpp
+++ b/tests/DrawingEffect_shader_test.cpp
@@ -286,7 +286,8 @@ TEST_F(DrawingEffectShaderTest, Median3)
 	std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
 	gs_matrix_pop();
-	gs_projection_pop();	gs_viewport_pop();
+	gs_projection_pop();
+	gs_viewport_pop();
 
 	unique_gs_stagesurf_t stagesurf = make_unique_gs_stagesurf(width, height, colorFormat);
 	gs_stage_texture(stagesurf.get(), targetTexture.get());

--- a/tests/DrawingEffect_shader_test.cpp
+++ b/tests/DrawingEffect_shader_test.cpp
@@ -257,12 +257,8 @@ TEST_F(DrawingEffectShaderTest, Median3)
 
 	auto &effect = drawingEffect->effect;
 
-	std::vector<float> sequence;
-	for (int i = 0; i < 3; ++i) {
-		sequence.push_back(std::uniform_real_distribution<float>(0.0f, 1.0f)(rng));
-	}
-	std::sort(sequence.begin(), sequence.end());
-	float expected_median = sequence[1];
+	std::vector<float> sequence{0.1, 0.5, 0.9};
+	std::shuffle(sequence.begin(), sequence.end(), rng);
 
 	gs_set_render_target(targetTexture.get(), nullptr);
 
@@ -296,9 +292,10 @@ TEST_F(DrawingEffectShaderTest, Median3)
 	uint32_t linesize = 0;
 	ASSERT_TRUE(gs_stagesurface_map(stagesurf.get(), &data, &linesize));
 
-	uint8_t expected_median_8bit = static_cast<uint8_t>(expected_median * 255.0f);
-	// Allow for a small tolerance due to float to uint8_t conversion and shader precision
-	ASSERT_NEAR(expected_median_8bit, data[0], 1) << "at byte index 0";
+	for (std::size_t i = 0; i < height * linesize; i++) {
+		std::cout << "data[" << i << "] = " << static_cast<int>(data[i]) << std::endl;
+	}
+	ASSERT_EQ(128, data[0]) << "at byte index 0";
 
 	gs_stagesurface_unmap(stagesurf.get());
 }

--- a/tests/DrawingEffect_shader_test.cpp
+++ b/tests/DrawingEffect_shader_test.cpp
@@ -16,9 +16,11 @@ You should have received a copy of the GNU General Public License along
 with this program. If not, see <https://www.gnu.org/licenses/>
 */
 
+#include <algorithm>
 #include <iostream>
 #include <memory>
 #include <thread>
+#include <random>
 
 #include <obs-module.h>
 #include <opencv2/opencv.hpp>
@@ -104,10 +106,10 @@ TEST_F(DrawingEffectShaderTest, ExtractLuminance)
 
 	int width = 1;
 	int height = 1;
-	gs_color_format colorFormat = GS_BGRX;
+	gs_color_format colorFormat = GS_RGBA;
 
-	// Red color in BGRX format {B, G, R, A}
-	const std::vector<uint8_t> sourcePixels = {0, 0, 255, 255};
+	// Red color in RGBA format {R, G, B, A}
+	const std::vector<uint8_t> sourcePixels = {255, 0, 0, 255};
 	const uint8_t *sourceData = sourcePixels.data();
 	auto sourceTexture = make_unique_gs_texture(width, height, colorFormat, 1, &sourceData, 0);
 	auto targetTexture = make_unique_gs_texture(width, height, colorFormat, 1, nullptr, GS_RENDER_TARGET);
@@ -136,16 +138,96 @@ TEST_F(DrawingEffectShaderTest, ExtractLuminance)
 	ASSERT_TRUE(gs_stagesurface_map(stagesurf.get(), &data, &linesize));
 
 	// The shader calculates luma = dot(color.rgb, float3(0.2126, 0.7152, 0.0722)).
-	// Assuming the texture sampler correctly maps BGRX to RGB for the shader,
-	// the input color (0, 0, 255) becomes (1.0, 0.0, 0.0) in the shader.
+	// Assuming the texture sampler correctly maps RGBA to RGB for the shader,
+	// the input color (255, 0, 0) becomes (1.0, 0.0, 0.0) in the shader.
 	// luma = 0.2126 * 1.0 + 0.7152 * 0.0 + 0.0722 * 0.0 = 0.2126.
 	// The output color is (luma, luma, luma, 1.0).
 	// In 8-bit format, this is 0.2126 * 255 = 54.213, which is 54.
-	// The output pixel in BGRX should be (54, 54, 54, 255).
-	EXPECT_EQ(54, data[0]);  // Blue
+	// The output pixel in RGBA should be (54, 54, 54, 255).
+	EXPECT_EQ(54, data[0]);  // Red
 	EXPECT_EQ(54, data[1]);  // Green
-	EXPECT_EQ(54, data[2]);  // Red
+	EXPECT_EQ(54, data[2]);  // Blue
 	EXPECT_EQ(255, data[3]); // Alpha
+
+	gs_stagesurface_unmap(stagesurf.get());
+}
+
+TEST_F(DrawingEffectShaderTest, Median9)
+{
+	std::mt19937_64 rng(std::random_device{}());
+
+	graphics_context_guard guard;
+
+	int width = 1;
+	int height = 1;
+	gs_color_format colorFormat = GS_BGRX;
+
+	const std::vector<uint8_t> sourcePixels(width * height * 4, 255);
+	const uint8_t *sourceData = sourcePixels.data();
+	auto sourceTexture = make_unique_gs_texture(width, height, colorFormat, 1, &sourceData, 0);
+	auto targetTexture = make_unique_gs_texture(width, height, colorFormat, 1, nullptr, GS_RENDER_TARGET);
+
+	gs_viewport_push();
+	gs_projection_push();
+	gs_matrix_push();
+
+	gs_set_viewport(0, 0, width, height);
+	gs_ortho(0.0f, (float)width, 0.0f, (float)height, -100.0f, 100.0f);
+	gs_matrix_identity();
+
+	auto &effect = drawingEffect->effect;
+
+	std::vector<float> sequence{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9};
+	std::shuffle(sequence.begin(), sequence.end(), rng);
+
+	gs_set_render_target(targetTexture.get(), nullptr);
+
+	vec4 clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+	gs_clear(GS_CLEAR_COLOR, &clearColor, 1.0f, 0);
+
+	gs_eparam_t *floatV0 = gs_effect_get_param_by_name(effect.get(), "v0");
+	gs_eparam_t *floatV1 = gs_effect_get_param_by_name(effect.get(), "v1");
+	gs_eparam_t *floatV2 = gs_effect_get_param_by_name(effect.get(), "v2");
+	gs_eparam_t *floatV3 = gs_effect_get_param_by_name(effect.get(), "v3");
+	gs_eparam_t *floatV4 = gs_effect_get_param_by_name(effect.get(), "v4");
+	gs_eparam_t *floatV5 = gs_effect_get_param_by_name(effect.get(), "v5");
+	gs_eparam_t *floatV6 = gs_effect_get_param_by_name(effect.get(), "v6");
+	gs_eparam_t *floatV7 = gs_effect_get_param_by_name(effect.get(), "v7");
+	gs_eparam_t *floatV8 = gs_effect_get_param_by_name(effect.get(), "v8");
+
+	gs_effect_set_float(floatV0, sequence[0]);
+	gs_effect_set_float(floatV1, sequence[1]);
+	gs_effect_set_float(floatV2, sequence[2]);
+	gs_effect_set_float(floatV3, sequence[3]);
+	gs_effect_set_float(floatV4, sequence[4]);
+	gs_effect_set_float(floatV5, sequence[5]);
+	gs_effect_set_float(floatV6, sequence[6]);
+	gs_effect_set_float(floatV7, sequence[7]);
+	gs_effect_set_float(floatV8, sequence[8]);
+
+	while (gs_effect_loop(effect.get(), "TestMedian9")) {
+		gs_effect_set_texture(drawingEffect->textureImage, sourceTexture.get());
+		gs_draw_sprite(sourceTexture.get(), 0, width, height);
+	}
+
+	gs_flush();
+	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+	gs_matrix_pop();
+	gs_projection_pop();
+	gs_viewport_pop();
+
+	unique_gs_stagesurf_t stagesurf = make_unique_gs_stagesurf(width, height, colorFormat);
+	gs_stage_texture(stagesurf.get(), targetTexture.get());
+
+	uint8_t *data = nullptr;
+	uint32_t linesize = 0;
+	ASSERT_TRUE(gs_stagesurface_map(stagesurf.get(), &data, &linesize));
+
+	for (std::size_t i = 0; i < height * linesize; i++) {
+		std::cout << "data[" << i << "] = " << static_cast<int>(data[i]) << std::endl;
+	}
+	ASSERT_EQ(128, data[0]) << "at byte index 0";
 
 	gs_stagesurface_unmap(stagesurf.get());
 }


### PR DESCRIPTION
This pull request adds new shader test cases for median filtering and improves the clarity and correctness of the existing luminance extraction test. The main changes involve adding shader code and corresponding C++ tests to verify the behavior of `median3` and `median9` functions, as well as updating the color format and comments in the luminance test for accuracy.

**New shader functionality and tests:**

* Added new uniform variables and techniques (`TestMedian9` and `TestMedian3`) to `drawing-test.effect` for testing the `median9` and `median3` functions with configurable float inputs.
* Introduced two new C++ test cases, `Median9` and `Median3`, in `DrawingEffect_shader_test.cpp` to verify the correct output of the new shader techniques. These tests randomize or shuffle input values, set shader parameters, and check the output pixel values for correctness.

**Improvements to existing tests:**

* Updated the `ExtractLuminance` test to use RGBA color format instead of BGRX, corrected the input pixel data, and clarified comments to match the new format and expected output. [[1]](diffhunk://#diff-e53c8f6a5871d28073acc01c75265cfd160214254128df29a0e32272f1f7a412L107-R112) [[2]](diffhunk://#diff-e53c8f6a5871d28073acc01c75265cfd160214254128df29a0e32272f1f7a412L139-R303)

**Test infrastructure enhancements:**

* Added includes for `<algorithm>` and `<random>` to support the new test logic.