### PR TITLE
Refactor 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ target_link_libraries(
     opencv_imgproc
     opencv_imgcodecs
     fmt::fmt
+    Backward::Interface
 )
 
 target_sources(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ target_sources(
 )
 
 if(BUILD_TESTING)
-target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE BUILD_TESTING)
+  target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE BUILD_TESTING)
 endif()
 
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ find_package(nlohmann_json CONFIG REQUIRED)
 find_package(OpenCV CONFIG REQUIRED core imgproc imgcodecs)
 find_package(semver CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
+find_package(Backward CONFIG REQUIRED)
 
 target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE NOMINMAX)
 
@@ -85,6 +86,7 @@ target_link_libraries(
     opencv_imgproc
     opencv_imgcodecs
     fmt::fmt
+    Backward::Interface
 )
 
 target_sources(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ find_package(fmt CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(OpenCV CONFIG REQUIRED core imgproc imgcodecs)
 find_package(semver CONFIG REQUIRED)
+find_package(Backward CONFIG REQUIRED)
 
 target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE NOMINMAX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,11 +67,10 @@ set(VCPKG_INSTALLED_DIR "${CMAKE_SOURCE_DIR}/vcpkg_installed")
 list(PREPEND CMAKE_PREFIX_PATH "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}")
 
 find_package(cpr CONFIG REQUIRED)
+find_package(fmt CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(OpenCV CONFIG REQUIRED core imgproc imgcodecs)
 find_package(semver CONFIG REQUIRED)
-find_package(fmt CONFIG REQUIRED)
-find_package(Backward CONFIG REQUIRED)
 
 target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE NOMINMAX)
 
@@ -86,7 +85,6 @@ target_link_libraries(
     opencv_imgproc
     opencv_imgcodecs
     fmt::fmt
-    Backward::Interface
 )
 
 target_sources(
@@ -97,6 +95,10 @@ target_sources(
     src/Core/RenderingContext.cpp
     src/plugin-main.c
 )
+
+if(BUILD_TESTING)
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE BUILD_TESTING)
+endif()
 
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})
 

--- a/src/BridgeUtils/AsyncTextureReader.hpp
+++ b/src/BridgeUtils/AsyncTextureReader.hpp
@@ -20,6 +20,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include <array>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <mutex>
@@ -30,7 +31,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 namespace KaitoTokyo {
 namespace BridgeUtils {
 
-namespace async_texture_reader_detail {
+namespace AsyncTextureReaderDetail {
 
 inline std::uint32_t getBytesPerPixel(const gs_color_format format)
 {
@@ -88,7 +89,7 @@ struct ScopedStageSurfMap {
 	ScopedStageSurfMap &operator=(ScopedStageSurfMap &&) = delete;
 };
 
-} // namespace async_texture_reader_detail
+} // namespace AsyncTextureReaderDetail
 
 /**
  * @class AsyncTextureReader
@@ -222,7 +223,7 @@ private:
 	std::array<std::vector<std::uint8_t>, 2> cpuBuffers;
 	std::atomic<std::size_t> activeCpuBufferIndex = {0};
 
-	std::array<kaito_tokyo::obs_bridge_utils::unique_gs_stagesurf_t, 2> stagesurfs;
+	std::array<KaitoTokyo::BridgeUtils::gs_stagesurf_t, 2> stagesurfs;
 	std::size_t gpuWriteIndex = 0;
 	std::mutex gpuMutex;
 };

--- a/src/BridgeUtils/ILogger.hpp
+++ b/src/BridgeUtils/ILogger.hpp
@@ -21,6 +21,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <cstdint>
 #include <cstdio>
 #include <iterator>
+#include <stdexcept>
 #include <string_view>
 #include <string>
 #include <utility>
@@ -59,6 +60,8 @@ public:
 	{
 		formatAndLog(LogLevel::Error, fmt, std::forward<Args>(args)...);
 	}
+
+	virtual void logException(const std::exception &e, std::string_view context) const noexcept = 0;
 
 protected:
 	enum class LogLevel : std::int8_t { Debug, Info, Warn, Error };

--- a/src/BridgeUtils/ObsLogger.hpp
+++ b/src/BridgeUtils/ObsLogger.hpp
@@ -18,11 +18,6 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #pragma once
 
-#if defined(__linux__)
-#define BACKWARD_HAS_DW 1
-#define BACKWARD_HAS_LIBUNWIND 1
-#endif
-
 #include <backward.hpp>
 
 #include <util/base.h>

--- a/src/BridgeUtils/ObsLogger.hpp
+++ b/src/BridgeUtils/ObsLogger.hpp
@@ -18,6 +18,13 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #pragma once
 
+#if defined(__linux__)
+#define BACKWARD_HAS_DW 1
+#define BACKWARD_HAS_LIBUNWIND 1
+#endif
+
+#include <backward.hpp>
+
 #include <util/base.h>
 
 #include "ILogger.hpp"
@@ -31,7 +38,7 @@ public:
 	ObsLogger(const std::string &_prefix) : prefix(_prefix) {}
 
 protected:
-	virtual void log(LogLevel level, std::string_view message) const noexcept
+	void log(LogLevel level, std::string_view message) const noexcept override
 	{
 		int blogLevel;
 		switch (level) {
@@ -55,8 +62,25 @@ protected:
 		blog(blogLevel, "%.*s", static_cast<int>(message.length()), message.data());
 	}
 
+	void logException(const std::exception &e, std::string_view context) const noexcept override
+	try {
+		error("{}: {}", context, e.what());
+
+		backward::StackTrace st;
+		st.load_here(32);
+
+		std::stringstream ss;
+		backward::Printer p;
+		p.print(st, ss);
+		log(LogLevel::Error, fmt::format("{}--- Stack Trace ---\n{}", getPrefix(), ss.str()));
+	} catch (const std::exception &log_ex) {
+		fprintf(stderr, "[LOGGER FATAL] Failed during exception logging: %s\n", log_ex.what());
+	} catch (...) {
+		fprintf(stderr, "[LOGGER FATAL] Unknown error during exception logging.\n");
+	}
+
 protected:
-	virtual std::string_view getPrefix() const noexcept { return prefix; }
+	std::string_view getPrefix() const noexcept override { return prefix; }
 
 private:
 	const std::string prefix;

--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -66,7 +66,7 @@ void MainPluginContext::getDefaults(obs_data_t *data)
 	obs_data_set_default_double(data, "motionAdaptiveFilteringMotionThreshold",
 				    preset.motionAdaptiveFilteringMotionThreshold);
 	obs_data_set_default_bool(data, "sobelUseLog", preset.sobelUseLog);
-	obs_data_set_default_double(data, "sobelScalingFactorDb", preset.sobelScalingFactorDb);
+	obs_data_set_default_double(data, "sobelScalingFactorDb", preset.sobelScalingFactor.db);
 }
 
 obs_properties_t *MainPluginContext::getProperties()
@@ -109,7 +109,7 @@ void MainPluginContext::update(obs_data_t *data)
 	preset.motionAdaptiveFilteringMotionThreshold =
 		obs_data_get_double(data, "motionAdaptiveFilteringMotionThreshold");
 	preset.sobelUseLog = obs_data_get_bool(data, "sobelUseLog");
-	preset.setSobelScalingFactorDb(obs_data_get_double(data, "sobelScalingFactorDb"));
+	preset.sobelScalingFactor = DecibelField::fromDbPow(obs_data_get_double(data, "sobelScalingFactorDb"));
 
 	if (renderingContext) {
 		renderingContext->updatePreset(preset);

--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -31,7 +31,7 @@ namespace ShowDraw {
 MainPluginContext::MainPluginContext(obs_data_t *settings, obs_source_t *_source)
 	: source{_source},
 	  logger("[" PLUGIN_NAME "] "),
-	  mainEffect(unique_obs_module_file("effects/main.effect"))
+	  mainEffect(unique_obs_module_file("effects/masin.effect"))
 {
 	std::atomic_store(&preset, std::make_shared<const Preset>());
 	update(settings);

--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -33,6 +33,7 @@ MainPluginContext::MainPluginContext(obs_data_t *settings, obs_source_t *_source
 	  logger("[" PLUGIN_NAME "] "),
 	  mainEffect(unique_obs_module_file("effects/main.effect"))
 {
+	std::atomic_store(&preset, std::make_shared<const Preset>());
 	update(settings);
 }
 
@@ -59,14 +60,14 @@ uint32_t MainPluginContext::getHeight() const noexcept
 
 void MainPluginContext::getDefaults(obs_data_t *data)
 {
-	Preset preset;
-	obs_data_set_default_int(data, "extractionMode", static_cast<int>(preset.extractionMode));
-	obs_data_set_default_bool(data, "medianFilterEnabled", preset.medianFilterEnabled);
-	obs_data_set_default_double(data, "motionAdaptiveFilteringStrength", preset.motionAdaptiveFilteringStrength);
+	Preset p;
+	obs_data_set_default_int(data, "extractionMode", static_cast<int>(p.extractionMode));
+	obs_data_set_default_bool(data, "medianFilterEnabled", p.medianFilterEnabled);
+	obs_data_set_default_double(data, "motionAdaptiveFilteringStrength", p.motionAdaptiveFilteringStrength);
 	obs_data_set_default_double(data, "motionAdaptiveFilteringMotionThreshold",
-				    preset.motionAdaptiveFilteringMotionThreshold);
-	obs_data_set_default_bool(data, "sobelUseLog", preset.sobelUseLog);
-	obs_data_set_default_double(data, "sobelScalingFactorDb", preset.sobelScalingFactor.db);
+				    p.motionAdaptiveFilteringMotionThreshold);
+	obs_data_set_default_bool(data, "sobelUseLog", p.sobelUseLog);
+	obs_data_set_default_double(data, "sobelScalingFactorDb", p.sobelScalingFactor.db);
 }
 
 obs_properties_t *MainPluginContext::getProperties()
@@ -103,17 +104,17 @@ obs_properties_t *MainPluginContext::getProperties()
 
 void MainPluginContext::update(obs_data_t *data)
 {
-	preset.extractionMode = static_cast<ExtractionMode>(obs_data_get_int(data, "extractionMode"));
-	preset.medianFilterEnabled = obs_data_get_bool(data, "medianFilterEnabled");
-	preset.motionAdaptiveFilteringStrength = obs_data_get_double(data, "motionAdaptiveFilteringStrength");
-	preset.motionAdaptiveFilteringMotionThreshold =
-		obs_data_get_double(data, "motionAdaptiveFilteringMotionThreshold");
-	preset.sobelUseLog = obs_data_get_bool(data, "sobelUseLog");
-	preset.sobelScalingFactor = DecibelField::fromDbPow(obs_data_get_double(data, "sobelScalingFactorDb"));
+	Preset newPreset = *std::atomic_load(&preset);
 
-	if (renderingContext) {
-		renderingContext->updatePreset(preset);
-	}
+	newPreset.extractionMode = static_cast<ExtractionMode>(obs_data_get_int(data, "extractionMode"));
+	newPreset.medianFilterEnabled = obs_data_get_bool(data, "medianFilterEnabled");
+	newPreset.motionAdaptiveFilteringStrength = obs_data_get_double(data, "motionAdaptiveFilteringStrength");
+	newPreset.motionAdaptiveFilteringMotionThreshold =
+		obs_data_get_double(data, "motionAdaptiveFilteringMotionThreshold");
+	newPreset.sobelUseLog = obs_data_get_bool(data, "sobelUseLog");
+	newPreset.sobelScalingFactor = DecibelField::fromDbAmp(obs_data_get_double(data, "sobelScalingFactorDb"));
+
+	std::atomic_store(&preset, std::make_shared<const Preset>(newPreset));
 }
 
 void MainPluginContext::activate()
@@ -139,7 +140,7 @@ void MainPluginContext::videoTick(float) {}
 void MainPluginContext::videoRender()
 {
 	if (renderingContext) {
-		renderingContext->videoRender();
+		renderingContext->videoRender(preset);
 	}
 }
 
@@ -157,8 +158,8 @@ try {
 
 	if (!renderingContext || frame->width != renderingContext->width || frame->height != renderingContext->height) {
 		GraphicsContextGuard guard;
-		renderingContext = std::make_shared<RenderingContext>(source, logger, mainEffect, frame->width,
-								      frame->height, preset);
+		renderingContext =
+			std::make_shared<RenderingContext>(source, logger, mainEffect, frame->width, frame->height);
 		GsUnique::drain();
 	}
 

--- a/src/Core/MainPluginContext.h
+++ b/src/Core/MainPluginContext.h
@@ -32,6 +32,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <atomic>
 #include <future>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include "../BridgeUtils/ObsLogger.hpp"
 
@@ -55,7 +56,7 @@ public:
 	const KaitoTokyo::BridgeUtils::ObsLogger logger;
 	const MainEffect mainEffect;
 
-	Preset preset;
+	std::shared_ptr<const Preset> preset;
 	std::shared_ptr<RenderingContext> renderingContext = nullptr;
 
 	MainPluginContext(obs_data_t *settings, obs_source_t *source);
@@ -82,7 +83,6 @@ public:
 	void videoRender();
 
 	obs_source_t *getFilter() const noexcept;
-	Preset getRunningPreset() const noexcept;
 };
 
 } // namespace ShowDraw

--- a/src/Core/MainPluginContext_c.cpp
+++ b/src/Core/MainPluginContext_c.cpp
@@ -28,6 +28,12 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 using namespace KaitoTokyo::ShowDraw;
 using namespace KaitoTokyo::BridgeUtils;
 
+#ifdef BUILD_TESTING
+#define RETHROW_IF_TESTING() throw
+#else
+#define RETHROW_IF_TESTING()
+#endif
+
 const char *main_plugin_context_get_name(void *)
 {
 	return obs_module_text("pluginName");
@@ -39,17 +45,20 @@ try {
 	auto self = std::make_shared<MainPluginContext>(settings, source);
 	return new std::shared_ptr<MainPluginContext>(self);
 } catch (const std::exception &e) {
-	printf("error: [" PLUGIN_NAME "] Failed to create context: %s", e.what());
+	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to create context: %s", e.what());
+	RETHROW_IF_TESTING();
 	return nullptr;
 } catch (...) {
-	printf("error: [" PLUGIN_NAME "] Failed to create context: unknown error");
+	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to create context: unknown error");
+	RETHROW_IF_TESTING();
 	return nullptr;
 }
 
 void main_plugin_context_destroy(void *data)
 try {
-	if (!data)
+	if (!data) {
 		throw std::invalid_argument("data is null");
+	}
 
 	auto selfPtr = static_cast<std::shared_ptr<MainPluginContext> *>(data);
 	(*selfPtr)->shutdown();
@@ -58,9 +67,11 @@ try {
 	GraphicsContextGuard guard;
 	GsUnique::drain();
 } catch (const std::exception &e) {
-	printf("error: [" PLUGIN_NAME "] Failed to destroy context: %s", e.what());
+	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to destroy context: %s", e.what());
+	RETHROW_IF_TESTING();
 } catch (...) {
-	printf("error: [" PLUGIN_NAME "] Failed to destroy context: unknown error");
+	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to destroy context: unknown error");
+	RETHROW_IF_TESTING();
 }
 
 #define GET_CONTEXT(data) static_cast<std::shared_ptr<MainPluginContext> *>(data)->get()
@@ -70,7 +81,7 @@ std::uint32_t main_plugin_context_get_width(void *data)
 	if (data) {
 		return GET_CONTEXT(data)->getWidth();
 	} else {
-		printf("error: [" PLUGIN_NAME "] Failed to get width: data is null");
+		blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to get width: data is null");
 		return 0;
 	}
 }
@@ -80,7 +91,7 @@ std::uint32_t main_plugin_context_get_height(void *data)
 	if (data) {
 		return GET_CONTEXT(data)->getHeight();
 	} else {
-		printf("error: [" PLUGIN_NAME "] Failed to get height: data is null");
+		blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to get height: data is null");
 		return 0;
 	}
 }
@@ -93,10 +104,10 @@ void main_plugin_context_get_defaults(obs_data_t *data)
 obs_properties_t *main_plugin_context_get_properties(void *data)
 {
 	if (data) {
-		printf("error: [" PLUGIN_NAME "] OK");
+		blog(LOG_INFO, "[" PLUGIN_NAME "] OK");
 		return GET_CONTEXT(data)->getProperties();
 	} else {
-		printf("error: [" PLUGIN_NAME "] Failed to get properties: data is null");
+		blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to get properties: data is null");
 		return obs_properties_create();
 	}
 }
@@ -106,7 +117,7 @@ void main_plugin_context_update(void *data, obs_data_t *settings)
 	if (data) {
 		GET_CONTEXT(data)->update(settings);
 	} else {
-		printf("error: [" PLUGIN_NAME "] Failed to update settings: data is null");
+		blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to update settings: data is null");
 	}
 }
 
@@ -115,7 +126,7 @@ void main_plugin_context_activate(void *data)
 	if (data) {
 		GET_CONTEXT(data)->activate();
 	} else {
-		printf("error: [" PLUGIN_NAME "] Failed to activate context: data is null");
+		blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to activate context: data is null");
 	}
 }
 void main_plugin_context_deactivate(void *data)
@@ -123,7 +134,7 @@ void main_plugin_context_deactivate(void *data)
 	if (data) {
 		GET_CONTEXT(data)->deactivate();
 	} else {
-		printf("error: [" PLUGIN_NAME "] Failed to deactivate context: data is null");
+		blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to deactivate context: data is null");
 	}
 }
 void main_plugin_context_show(void *data)
@@ -131,7 +142,7 @@ void main_plugin_context_show(void *data)
 	if (data) {
 		GET_CONTEXT(data)->show();
 	} else {
-		printf("error: [" PLUGIN_NAME "] Failed to show context: data is null");
+		blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to show context: data is null");
 	}
 }
 void main_plugin_context_hide(void *data)
@@ -139,7 +150,7 @@ void main_plugin_context_hide(void *data)
 	if (data) {
 		GET_CONTEXT(data)->hide();
 	} else {
-		printf("error: [" PLUGIN_NAME "] Failed to hide context: data is null");
+		blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to hide context: data is null");
 	}
 }
 void main_plugin_context_video_tick(void *data, float s)
@@ -147,7 +158,7 @@ void main_plugin_context_video_tick(void *data, float s)
 	if (data) {
 		GET_CONTEXT(data)->videoTick(s);
 	} else {
-		printf("error: [" PLUGIN_NAME "] Failed to tick video: data is null");
+		blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to tick video: data is null");
 	}
 }
 
@@ -159,19 +170,28 @@ try {
 		blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to render video: data is null");
 	}
 } catch (const std::exception &e) {
-	printf("error: [" PLUGIN_NAME "] Failed to render video: %s", e.what());
+	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to render video: %s", e.what());
+	RETHROW_IF_TESTING();
 } catch (...) {
-	printf("error: [" PLUGIN_NAME "] Failed to render video: unknown error");
+	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to render video: unknown error");
+	RETHROW_IF_TESTING();
 }
 
 struct obs_source_frame *main_plugin_context_filter_video(void *data, struct obs_source_frame *frame)
 try {
-	return data ? GET_CONTEXT(data)->filterVideo(frame) : frame;
+	if (frame) {
+		return GET_CONTEXT(data)->filterVideo(frame);
+	} else {
+		blog(LOG_ERROR, "[" PLUGIN_NAME "] frame is null");
+		return frame;
+	}
 } catch (const std::exception &e) {
-	printf("error: [" PLUGIN_NAME "] Failed to filter video: %s", e.what());
+	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to filter video: %s", e.what());
+	RETHROW_IF_TESTING();
 	return frame;
 } catch (...) {
-	printf("error: [" PLUGIN_NAME "] Failed to filter video: unknown error");
+	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to filter video: unknown error");
+	RETHROW_IF_TESTING();
 	return frame;
 }
 
@@ -185,7 +205,9 @@ try {
 	GraphicsContextGuard guard;
 	GsUnique::drain();
 } catch (const std::exception &e) {
-	printf("error: [" PLUGIN_NAME "] Failed to unload main plugin context: %s", e.what());
+	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to unload main plugin context: %s", e.what());
+	RETHROW_IF_TESTING();
 } catch (...) {
-	printf("error: [" PLUGIN_NAME "] Failed to unload main plugin context: unknown error");
+	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to unload main plugin context: unknown error");
+	RETHROW_IF_TESTING();
 }

--- a/src/Core/MainPluginContext_c.cpp
+++ b/src/Core/MainPluginContext_c.cpp
@@ -30,10 +30,10 @@ using namespace KaitoTokyo::BridgeUtils;
 
 namespace {
 
-inline ILogger& logger()
+inline ILogger &logger()
 {
-    static ObsLogger instance("[" PLUGIN_NAME "] ");
-    return instance;
+	static ObsLogger instance("[" PLUGIN_NAME "] ");
+	return instance;
 }
 
 } // namespace

--- a/src/Core/MainPluginContext_c.cpp
+++ b/src/Core/MainPluginContext_c.cpp
@@ -29,7 +29,12 @@ using namespace KaitoTokyo::ShowDraw;
 using namespace KaitoTokyo::BridgeUtils;
 
 #ifdef BUILD_TESTING
+#if defined(_MSC_VER)
+#include <intrin.h>
+#define RETHROW_IF_TESTING() __debugbreak()
+#else
 #define RETHROW_IF_TESTING() throw
+#endif
 #else
 #define RETHROW_IF_TESTING()
 #endif

--- a/src/Core/Preset.hpp
+++ b/src/Core/Preset.hpp
@@ -29,6 +29,18 @@ enum class ExtractionMode {
 	SobelMagnitude = 400,
 };
 
+struct DecibelField {
+	double db;
+	double linear;
+
+	static DecibelField fromDbPow(double dbValue) { return DecibelField(dbValue, std::pow(10.0, dbValue / 10.0)); }
+
+	static DecibelField fromDbAmp(double dbValue) { return DecibelField(dbValue, std::pow(10.0, dbValue / 20.0)); }
+
+private:
+	DecibelField(double _dbValue, double _linearValue) : db(_dbValue), linear(_linearValue) {}
+};
+
 struct Preset {
 public:
 	ExtractionMode extractionMode = ExtractionMode::Default;
@@ -39,14 +51,7 @@ public:
 	double motionAdaptiveFilteringMotionThreshold = 0.3;
 
 	bool sobelUseLog = true;
-	double sobelScalingFactorDb = 10.0;
-	double sobelScalingFactor = 3.1622776602; // = pow(10, 10/20)
-
-	void setSobelScalingFactorDb(double v)
-	{
-		sobelScalingFactorDb = v;
-		sobelScalingFactor = std::pow(10.0, v / 20.0);
-	}
+	DecibelField sobelScalingFactor = DecibelField::fromDbPow(10.0);
 };
 
 } // namespace ShowDraw

--- a/src/Core/RenderingContext.cpp
+++ b/src/Core/RenderingContext.cpp
@@ -72,6 +72,7 @@ void RenderingContext::videoRender()
 	const unique_gs_texture_t *grayscaleResult;
 
 	if (isProcessingNewFrame) {
+		isProcessingNewFrame = false;
 		if (extractionMode >= ExtractionMode::Passthrough) {
 			mainEffect.drawSource(bgrxSource, source);
 		}

--- a/src/Core/RenderingContext.cpp
+++ b/src/Core/RenderingContext.cpp
@@ -29,14 +29,12 @@ namespace KaitoTokyo {
 namespace ShowDraw {
 
 RenderingContext::RenderingContext(obs_source_t *_source, const KaitoTokyo::BridgeUtils::ILogger &_logger,
-				   const MainEffect &_mainEffect, std::uint32_t _width, std::uint32_t _height,
-				   const Preset &_preset)
+				   const MainEffect &_mainEffect, std::uint32_t _width, std::uint32_t _height)
 	: source(_source),
 	  logger(_logger),
 	  mainEffect(_mainEffect),
 	  width(_width),
 	  height(_height),
-	  preset(_preset),
 	  bgrxSource(make_unique_gs_texture(width, height, GS_BGRX, 1, nullptr, GS_RENDER_TARGET)),
 	  r8SourceGrayscale(make_unique_gs_texture(width, height, GS_R8, 1, nullptr, GS_RENDER_TARGET)),
 	  r8MedianFilteredGrayscale(make_unique_gs_texture(width, height, GS_R8, 1, nullptr, GS_RENDER_TARGET)),
@@ -63,18 +61,15 @@ obs_source_frame *RenderingContext::filterVideo(obs_source_frame *frame)
 	return frame;
 }
 
-void RenderingContext::videoRender()
+void RenderingContext::videoRender(const std::shared_ptr<const Preset> &preset)
 {
-	ExtractionMode extractionMode = getExtractionMode();
+	ExtractionMode extractionMode = getExtractionMode(*preset);
 
 	bool isProcessingNewFrame = doesNextVideoRenderReceiveNewFrame.exchange(false);
 
 	const unique_gs_texture_t *grayscaleResult;
 
-	const Preset _preset = preset;
-
 	if (isProcessingNewFrame) {
-		isProcessingNewFrame = false;
 		if (extractionMode >= ExtractionMode::Passthrough) {
 			mainEffect.drawSource(bgrxSource, source);
 		}
@@ -83,19 +78,19 @@ void RenderingContext::videoRender()
 			mainEffect.applyConvertToGrayscale(r8SourceGrayscale, bgrxSource);
 			grayscaleResult = &r8SourceGrayscale;
 
-			if (preset.medianFilterEnabled) {
+			if (preset->medianFilterEnabled) {
 				mainEffect.applyMedianFilter(r8MedianFilteredGrayscale, r32fIntermediate,
 							     *grayscaleResult);
 				grayscaleResult = &r8MedianFilteredGrayscale;
 			}
 
-			if (preset.motionAdaptiveFilteringStrength > 0.0) {
+			if (preset->motionAdaptiveFilteringStrength > 0.0) {
 				std::swap(r8MotionAdaptiveGrayscales[0], r8MotionAdaptiveGrayscales[1]);
 				mainEffect.applyMotionAdaptiveFilter(
 					r8MotionAdaptiveGrayscales[0], r8MotionMap, r32fIntermediate, *grayscaleResult,
 					r8MotionAdaptiveGrayscales[1],
-					static_cast<float>(preset.motionAdaptiveFilteringStrength),
-					static_cast<float>(preset.motionAdaptiveFilteringMotionThreshold));
+					static_cast<float>(preset->motionAdaptiveFilteringStrength),
+					static_cast<float>(preset->motionAdaptiveFilteringMotionThreshold));
 				grayscaleResult = &r8MotionAdaptiveGrayscales[0];
 			}
 		}
@@ -103,8 +98,8 @@ void RenderingContext::videoRender()
 		if (extractionMode >= ExtractionMode::SobelMagnitude) {
 			mainEffect.applySobel(bgrxComplexSobel, *grayscaleResult);
 			mainEffect.applyFinalizeSobelMagnitude(r8FinalSobelMagnitude, bgrxComplexSobel,
-							       preset.sobelUseLog,
-							       static_cast<float>(preset.sobelScalingFactor.linear));
+							       preset->sobelUseLog,
+							       static_cast<float>(preset->sobelScalingFactor.linear));
 		}
 	}
 
@@ -117,11 +112,6 @@ void RenderingContext::videoRender()
 	} else if (extractionMode == ExtractionMode::SobelMagnitude) {
 		mainEffect.drawGrayscaleTexture(r8FinalSobelMagnitude);
 	}
-}
-
-void RenderingContext::updatePreset(const Preset &newPreset)
-{
-	preset = newPreset;
 }
 
 } // namespace ShowDraw

--- a/src/Core/RenderingContext.cpp
+++ b/src/Core/RenderingContext.cpp
@@ -71,6 +71,8 @@ void RenderingContext::videoRender()
 
 	const unique_gs_texture_t *grayscaleResult;
 
+	const Preset _preset = preset;
+
 	if (isProcessingNewFrame) {
 		isProcessingNewFrame = false;
 		if (extractionMode >= ExtractionMode::Passthrough) {
@@ -102,7 +104,7 @@ void RenderingContext::videoRender()
 			mainEffect.applySobel(bgrxComplexSobel, *grayscaleResult);
 			mainEffect.applyFinalizeSobelMagnitude(r8FinalSobelMagnitude, bgrxComplexSobel,
 							       preset.sobelUseLog,
-							       static_cast<float>(preset.sobelScalingFactor));
+							       static_cast<float>(preset.sobelScalingFactor.linear));
 		}
 	}
 

--- a/src/Core/RenderingContext.hpp
+++ b/src/Core/RenderingContext.hpp
@@ -21,6 +21,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <memory>
 
 #include <obs.h>
 
@@ -41,8 +42,6 @@ public:
 	const std::uint32_t width;
 	const std::uint32_t height;
 
-	Preset preset;
-
 	const KaitoTokyo::BridgeUtils::unique_gs_texture_t bgrxSource;
 	const KaitoTokyo::BridgeUtils::unique_gs_texture_t r8SourceGrayscale;
 	const KaitoTokyo::BridgeUtils::unique_gs_texture_t r8MedianFilteredGrayscale;
@@ -61,19 +60,17 @@ private:
 
 public:
 	RenderingContext(obs_source_t *source, const KaitoTokyo::BridgeUtils::ILogger &logger,
-			 const MainEffect &mainEffect, std::uint32_t width, std::uint32_t height, const Preset &preset);
+			 const MainEffect &mainEffect, std::uint32_t width, std::uint32_t height);
 	~RenderingContext() noexcept;
 
 	void videoTick(float seconds);
 	obs_source_frame *filterVideo(obs_source_frame *frame);
-	void videoRender();
-	void updatePreset(const Preset &preset);
+	void videoRender(const std::shared_ptr<const Preset> &preset);
 
 private:
-	ExtractionMode getExtractionMode() const noexcept
+	static ExtractionMode getExtractionMode(const Preset &p) noexcept
 	{
-		return preset.extractionMode == ExtractionMode::Default ? ExtractionMode::SobelMagnitude
-									: preset.extractionMode;
+		return p.extractionMode == ExtractionMode::Default ? ExtractionMode::SobelMagnitude : p.extractionMode;
 	}
 };
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -27,7 +27,6 @@
         "png",
         "webp"
       ]
-    },
-    "backward-cpp"
+    }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -15,6 +15,7 @@
       "name": "directxtk",
       "platform": "windows"
     },
+    "fmt",
     "gtest",
     "neargye-semver",
     "nlohmann-json",
@@ -27,6 +28,6 @@
         "webp"
       ]
     },
-    "fmt"
+    "backward-cpp"
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -27,6 +27,7 @@
         "png",
         "webp"
       ]
-    }
+    },
+    "backward-cpp"
   ]
 }


### PR DESCRIPTION
This pull request introduces significant improvements to thread safety, error handling, and code clarity, especially around preset management and logging. The most important changes include making the `Preset` configuration atomic and thread-safe, refactoring error reporting to use the OBS logging system, and updating the `Preset` structure to use a new `DecibelField` type for clarity and maintainability.

### Thread safety and preset management
* Refactored `MainPluginContext` to store the `Preset` as a `std::shared_ptr<const Preset>` and use atomic operations for thread-safe updates and access. This ensures that preset changes are safe in multi-threaded contexts. [[1]](diffhunk://#diff-053c68a2145dddf96e5da0ca56ee213ce0d2f521b65788494bbdc8eeb570b872L106-R117) [[2]](diffhunk://#diff-053c68a2145dddf96e5da0ca56ee213ce0d2f521b65788494bbdc8eeb570b872L62-R70) [[3]](diffhunk://#diff-3d15422a694d33b7267ddf3c4a970433df4ce699ae3c9173d0577711fb443fddL58-R59) [[4]](diffhunk://#diff-3d15422a694d33b7267ddf3c4a970433df4ce699ae3c9173d0577711fb443fddL85)
* Updated all usages of `Preset` in `MainPluginContext` and `RenderingContext` to use the new atomic/shared pointer approach, including passing the preset to rendering methods. [[1]](diffhunk://#diff-053c68a2145dddf96e5da0ca56ee213ce0d2f521b65788494bbdc8eeb570b872L142-R143) [[2]](diffhunk://#diff-053c68a2145dddf96e5da0ca56ee213ce0d2f521b65788494bbdc8eeb570b872L160-R162) [[3]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L32-L39) [[4]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L66-R66)

### Error handling and logging
* Replaced all `printf` error messages in the C API implementation with calls to the OBS `blog` logging system, improving integration with OBS and log visibility. [[1]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L42-R61) [[2]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L61-R74) [[3]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L73-R84) [[4]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L83-R94) [[5]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L96-R110) [[6]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L109-R120) [[7]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L118-R161) [[8]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L162-R194) [[9]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L188-R212)
* Added a `RETHROW_IF_TESTING` macro to rethrow exceptions in test builds, improving testability and error detection during automated testing. [[1]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006R31-R36) [[2]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L42-R61) [[3]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L61-R74) [[4]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L162-R194) [[5]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L188-R212)

### Preset and configuration improvements
* Introduced a new `DecibelField` struct to encapsulate decibel and linear values, replacing raw double fields and manual conversions in `Preset`. This clarifies intent and reduces errors. [[1]](diffhunk://#diff-2cab5aff5c2adb1c1532416606a262b0715bc36a997e0091162cc7bfc5afeea1R32-R43) [[2]](diffhunk://#diff-2cab5aff5c2adb1c1532416606a262b0715bc36a997e0091162cc7bfc5afeea1L42-R54)
* Updated all code that previously used `sobelScalingFactorDb` and `sobelScalingFactor` to use the new `DecibelField` type and its conversion methods. [[1]](diffhunk://#diff-053c68a2145dddf96e5da0ca56ee213ce0d2f521b65788494bbdc8eeb570b872L62-R70) [[2]](diffhunk://#diff-053c68a2145dddf96e5da0ca56ee213ce0d2f521b65788494bbdc8eeb570b872L106-R117)

### Code style and naming consistency
* Renamed the namespace `async_texture_reader_detail` to `AsyncTextureReaderDetail` for consistency with naming conventions. [[1]](diffhunk://#diff-414119f2a2a016953edb5de096f35ca34e9c786d3155854d84f967329fd2f509L33-R34) [[2]](diffhunk://#diff-414119f2a2a016953edb5de096f35ca34e9c786d3155854d84f967329fd2f509L91-R92)
* Changed type usage in `AsyncTextureReader` to use the correct namespace for `gs_stagesurf_t`.

### Build system and dependency tweaks
* Made minor adjustments in `CMakeLists.txt` to fix the order of `find_package(fmt ...)` and add conditional compilation definitions for testing. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR70-L73) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR99-R102)
* Added missing includes (e.g., `<cstddef>`, `<mutex>`) to support new code. [[1]](diffhunk://#diff-414119f2a2a016953edb5de096f35ca34e9c786d3155854d84f967329fd2f509R23) [[2]](diffhunk://#diff-3d15422a694d33b7267ddf3c4a970433df4ce699ae3c9173d0577711fb443fddR35)