### PR TITLE
Update ObsLogger.hpp

### DIFF
--- a/src/BridgeUtils/ObsLogger.hpp
+++ b/src/BridgeUtils/ObsLogger.hpp
@@ -18,6 +18,10 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #pragma once
 
+#include <mutex>
+#include <sstream>
+#include <string_view>
+
 #include <backward.hpp>
 
 #include <util/base.h>
@@ -30,55 +34,67 @@ namespace BridgeUtils {
 
 class ObsLogger final : public ILogger {
 public:
-	ObsLogger(const std::string &_prefix) : prefix(_prefix) {}
+    ObsLogger(const std::string &_prefix) : prefix(_prefix) {}
 
 protected:
-	void log(LogLevel level, std::string_view message) const noexcept override
-	{
-		int blogLevel;
-		switch (level) {
-		case LogLevel::Debug:
-			blogLevel = LOG_DEBUG;
-			break;
-		case LogLevel::Info:
-			blogLevel = LOG_INFO;
-			break;
-		case LogLevel::Warn:
-			blogLevel = LOG_WARNING;
-			break;
-		case LogLevel::Error:
-			blogLevel = LOG_ERROR;
-			break;
-		default:
-			fprintf(stderr, "[LOGGER FATAL] Unknown log level: %d\n", static_cast<int>(level));
-			return;
-		}
+    void log(LogLevel level, std::string_view message) const noexcept override
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        int blogLevel;
+        switch (level) {
+        case LogLevel::Debug:
+            blogLevel = LOG_DEBUG;
+            break;
+        case LogLevel::Info:
+            blogLevel = LOG_INFO;
+            break;
+        case LogLevel::Warn:
+            blogLevel = LOG_WARNING;
+            break;
+        case LogLevel::Error:
+            blogLevel = LOG_ERROR;
+            break;
+        default:
+            fprintf(stderr, "[LOGGER FATAL] Unknown log level: %d\n", static_cast<int>(level));
+            return;
+        }
 
-		blog(blogLevel, "%.*s", static_cast<int>(message.length()), message.data());
-	}
+        constexpr size_t MAX_LOG_CHUNK_SIZE = 4000;
 
-	void logException(const std::exception &e, std::string_view context) const noexcept override
-	try {
-		error("{}: {}", context, e.what());
+        if (message.length() <= MAX_LOG_CHUNK_SIZE) {
+            blog(blogLevel, "%.*s", static_cast<int>(message.length()), message.data());
+        } else {
+            for (size_t i = 0; i < message.length(); i += MAX_LOG_CHUNK_SIZE) {
+                const auto chunk = message.substr(i, MAX_LOG_CHUNK_SIZE);
+                blog(blogLevel, "%.*s", static_cast<int>(chunk.length()), chunk.data());
+            }
+        }
+    }
 
-		backward::StackTrace st;
-		st.load_here(32);
+    void logException(const std::exception &e, std::string_view context) const noexcept override
+    try {
+        std::stringstream ss;
+        ss << context.data() << ": " << e.what() << "\n";
 
-		std::stringstream ss;
-		backward::Printer p;
-		p.print(st, ss);
-		log(LogLevel::Error, fmt::format("{}--- Stack Trace ---\n{}", getPrefix(), ss.str()));
-	} catch (const std::exception &log_ex) {
-		fprintf(stderr, "[LOGGER FATAL] Failed during exception logging: %s\n", log_ex.what());
-	} catch (...) {
-		fprintf(stderr, "[LOGGER FATAL] Unknown error during exception logging.\n");
-	}
+        backward::StackTrace st;
+        st.load_here(32);
+
+        backward::Printer p;
+        p.print(st, ss);
+
+        error("--- Stack Trace ---\n{}", ss.str());        
+    } catch (const std::exception &log_ex) {
+        fprintf(stderr, "[LOGGER FATAL] Failed during exception logging: %s\n", log_ex.what());
+    } catch (...) {
+        fprintf(stderr, "[LOGGER FATAL] Unknown error during exception logging.\n");
+    }
 
 protected:
-	std::string_view getPrefix() const noexcept override { return prefix; }
+    std::string_view getPrefix() const noexcept override { return prefix; }
 
 private:
-	const std::string prefix;
+    const std::string prefix;
+    mutable std::mutex mtx;
 };
 
 } // namespace BridgeUtils


### PR DESCRIPTION
This pull request improves the robustness and reliability of the `ObsLogger` class by adding thread safety and enhancing how large log messages and exceptions are handled. The most important changes are grouped below:

**Thread safety improvements:**

* Added a `std::mutex` member (`mtx`) to the `ObsLogger` class and wrapped the `log` method with a `std::lock_guard` to ensure thread-safe logging. [[1]](diffhunk://#diff-7a7584aed12a14e413dbe796951225294c660dac5abb1b65b78e60d6c7953223R21-R24) [[2]](diffhunk://#diff-7a7584aed12a14e413dbe796951225294c660dac5abb1b65b78e60d6c7953223R42) [[3]](diffhunk://#diff-7a7584aed12a14e413dbe796951225294c660dac5abb1b65b78e60d6c7953223R97)

**Logging improvements:**

* Updated the `log` method to split and log messages in chunks if they exceed 4000 characters, preventing truncation or errors with large log entries.

**Exception logging improvements:**

* Refactored `logException` to improve formatting and clarity of exception and stack trace output, ensuring better readability and context in error logs.